### PR TITLE
Get start:remote loading clusters

### DIFF
--- a/config/config.dev.json.example
+++ b/config/config.dev.json.example
@@ -1,5 +1,6 @@
 {
   "clusterApi": "https://api.supercluster.example.com:6443",
   "devServerPort": 9000,
-  "userScope": "user:full"
+  "userScope": "user:full",
+  "namespace": "mig"
 }

--- a/config/cr-examples/cluster.yaml
+++ b/config/cr-examples/cluster.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: clusterregistry.k8s.io/v1alpha1
+metadata:
+  namespace: mig
+  name: my-cluster
+  labels:
+    foo: bar
+spec:
+  kubernetesApiEndpoints:
+    serverEndpoints:
+      - clientCIDR: "0.0.0.0"
+        serverAddress: ""

--- a/config/cr-examples/migassetcollection.yaml
+++ b/config/cr-examples/migassetcollection.yaml
@@ -1,0 +1,15 @@
+apiVersion: migration.openshift.io/v1beta1
+kind: MigAssetCollection
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: my-assetcollection
+  namespace: mig
+spec:
+  namespaces:
+    - foo
+    - bar
+  # NOTE: Not sure if this will be on the final object
+  #images:
+    #- im1
+    #- im2

--- a/config/cr-examples/migcluster.yaml
+++ b/config/cr-examples/migcluster.yaml
@@ -1,0 +1,14 @@
+apiVersion: migration.openshift.io/v1beta1
+kind: MigCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: my-cluster
+  namespace: mig
+spec:
+  clusterRef:
+    name: my-cluster
+    namespace: mig
+  serviceAccountSecretRef:
+    name: my-cluster
+    namespace: openshift-config

--- a/config/cr-examples/migmigration.yaml
+++ b/config/cr-examples/migmigration.yaml
@@ -1,0 +1,11 @@
+apiVersion: migration.openshift.io/v1beta1
+kind: MigMigration
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: my-migration
+  namespace: mig
+spec:
+  migPlanRef:
+    name: my-plan
+    namespace: mig

--- a/config/cr-examples/migplan.yaml
+++ b/config/cr-examples/migplan.yaml
@@ -1,0 +1,16 @@
+apiVersion: migration.openshift.io/v1beta1
+kind: MigPlan
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: my-plan
+  namespace: mig
+spec:
+  srcClusterRef:
+    name: my-old-cluster
+  destClusterRef:
+    name: my-host-cluster
+  migrationStorageRef:
+    name: my-migrationstorage
+  migrationAssetCollectionRef:
+    name: my-migrationassetcollection

--- a/config/cr-examples/migstage.yaml
+++ b/config/cr-examples/migstage.yaml
@@ -1,0 +1,11 @@
+apiVersion: migration.openshift.io/v1beta1
+kind: MigStage
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: my-stage
+  namespace: mig
+spec:
+  migPlanRef:
+    name: my-plan
+    namespace: mig

--- a/config/cr-examples/migstorage.yaml
+++ b/config/cr-examples/migstorage.yaml
@@ -1,0 +1,15 @@
+apiVersion: migration.openshift.io/v1beta1
+kind: MigStorage
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: my-storage
+  namespace: mig
+spec:
+  backupStorageLocationRef:
+    name: my-backupstoragelocation
+  backupStorageLocationRef:
+    name: my-volumesnapshotlocation
+  migrationStorageSecretRef:
+    name: my-migstorage-auth
+    namespace: openshift-config

--- a/config/crds/cluster-registry.yaml
+++ b/config/crds/cluster-registry.yaml
@@ -1,0 +1,88 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    api: ""
+    kubebuilder.k8s.io: 1.0.3
+  name: clusters.clusterregistry.k8s.io
+spec:
+  group: clusterregistry.k8s.io
+  names:
+    kind: Cluster
+    plural: clusters
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            authInfo:
+              properties:
+                kontroller:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+                user:
+                  properties:
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  type: object
+              type: object
+            kubernetesApiEndpoints:
+              properties:
+                caBundle:
+                  format: byte
+                  type: string
+                serverEndpoints:
+                  items:
+                    properties:
+                      clientCIDR:
+                        type: string
+                      serverAddress:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastHeartbeatTime:
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+          type: object
+  version: v1alpha1

--- a/config/crds/migration_v1alpha1_migassetcollection.yaml
+++ b/config/crds/migration_v1alpha1_migassetcollection.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migassetcollections.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigAssetCollection
+    plural: migassetcollections
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            namespaces:
+              items:
+                type: string
+              type: array
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/migration_v1alpha1_migcluster.yaml
+++ b/config/crds/migration_v1alpha1_migcluster.yaml
@@ -1,0 +1,62 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migclusters.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigCluster
+    plural: migclusters
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            isHostCluster:
+              type: boolean
+            clusterRef:
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - name
+              - namespace
+              type: object
+            serviceAccountSecretRef:
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - name
+              - namespace
+              type: object
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/migration_v1alpha1_migmigration.yaml
+++ b/config/crds/migration_v1alpha1_migmigration.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migmigrations.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigMigration
+    plural: migmigrations
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            migPlanRef:
+              type: object
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/migration_v1alpha1_migplan.yaml
+++ b/config/crds/migration_v1alpha1_migplan.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migplans.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigPlan
+    plural: migplans
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            destClusterRef:
+              type: object
+            migAssetCollectionRef:
+              type: object
+            migStorageRef:
+              type: object
+            srcClusterRef:
+              type: object
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/migration_v1alpha1_migstage.yaml
+++ b/config/crds/migration_v1alpha1_migstage.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migstages.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigStage
+    plural: migstages
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            migPlanRef:
+              type: object
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/crds/migration_v1alpha1_migstorage.yaml
+++ b/config/crds/migration_v1alpha1_migstorage.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: migstorages.migration.openshift.io
+spec:
+  group: migration.openshift.io
+  names:
+    kind: MigStorage
+    plural: migstorages
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            backupStorageConfig:
+              properties:
+                awsBucketName:
+                  type: string
+                awsKmsKeyId:
+                  type: string
+                awsPublicUrl:
+                  type: string
+                awsRegion:
+                  type: string
+                awsSignatureVersion:
+                  type: string
+                azureResourceGroup:
+                  type: string
+                azureStorageAccount:
+                  type: string
+              required:
+              - awsBucketName
+              - awsRegion
+              - awsPublicUrl
+              - awsKmsKeyId
+              - awsSignatureVersion
+              - azureStorageAccount
+              - azureResourceGroup
+              type: object
+            backupStorageProvider:
+              type: string
+            volumeSnapshotConfig:
+              properties:
+                awsRegion:
+                  type: string
+                azureApiTimeout:
+                  type: string
+                azureResourceGroup:
+                  type: string
+              required:
+              - awsRegion
+              - azureApiTimeout
+              - azureResourceGroup
+              type: object
+            volumeSnapshotProvider:
+              type: string
+          required:
+          - volumeSnapshotProvider
+          - volumeSnapshotConfig
+          - backupStorageProvider
+          - backupStorageConfig
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/config/prep-crs/host.migcluster.yaml
+++ b/config/prep-crs/host.migcluster.yaml
@@ -1,0 +1,9 @@
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigCluster
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: host
+  namespace: mig
+spec:
+  isHostCluster: true

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -44,6 +44,7 @@ migMeta.oauth = {
   redirectUri: localConfig.redirectUri,
   userScope: localConfig.userScope,
 }
+migMeta.namespace = localConfig.namespace;
 
 htmlWebpackPluginOpt.migMeta = migMeta
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "clean": "yarn rimraf dist",
     "start": "DEVMODE=local webpack-dev-server --hot --color --progress --info=true --config config/webpack.dev.js",
     "start:remote": "./scripts/remote-dev.sh",
+    "prep-remote": "./scripts/prep-remote.sh",
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
     "test": "jest"

--- a/scripts/prep-remote.sh
+++ b/scripts/prep-remote.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+crd_dir=$_dir/../config/crds
+prep_dir=$_dir/../config/prep-crs
+
+oc create -f $crd_dir
+oc create -f $prep_dir

--- a/src/app/cluster/duck/operations.ts
+++ b/src/app/cluster/duck/operations.ts
@@ -6,6 +6,7 @@ import {
   ClusterRegistryResource,
   ClusterRegistryResourceKind,
 } from '../../../client/resources';
+import { MigResource, MigResourceKind } from '../../../client/resources';
 
 const clusterFetchSuccess = Creators.clusterFetchSuccess;
 const addClusterSuccess = Creators.addClusterSuccess;
@@ -48,10 +49,10 @@ const fetchClusters = () => {
     try {
       const { migMeta } = getState();
       const client: IClusterClient = ClientFactory.hostCluster(getState());
-      const resource = new ClusterRegistryResource(
-        ClusterRegistryResourceKind.Cluster, migMeta.namespace);
+      const resource = new MigResource(
+        MigResourceKind.MigCluster, migMeta.namespace);
       client.list(resource)
-        .then(res => dispatch(clusterFetchSuccess(res.data)))
+        .then(res => dispatch(clusterFetchSuccess(res.data.items)))
         .catch(err => AlertCreators.alertError('Failed to get clusters'));
     } catch (err) {
       dispatch(AlertCreators.alertError(err));

--- a/src/client/client_factory.ts
+++ b/src/client/client_factory.ts
@@ -23,14 +23,14 @@ export class ClientFactoryMissingApiRoot extends Error {
 
 export const ClientFactory = {
   hostCluster: (state: any) => {
-    if (!!state.auth.user) {
+    if (!state.auth.user) {
       throw new ClientFactoryMissingUserError();
     }
-    if (!!state.migMeta.clusterApi) {
+    if (!state.migMeta.clusterApi) {
       throw new ClientFactoryMissingApiRoot();
     }
 
-    return new ClusterClient(state.migMeta.clusterApi, state.auth.user.token);
+    return new ClusterClient(state.migMeta.clusterApi, state.auth.user.access_token);
   },
   forCluster: (clusterName: string, state: any) => {
     const clusters = state.kube.clusterregistry_k8s_io.clusters;

--- a/src/client/resources/mig.ts
+++ b/src/client/resources/mig.ts
@@ -25,4 +25,5 @@ export enum MigResourceKind {
   MigAssetCollection = 'migassetcollections',
   MigStage = 'migstages',
   MigMigration = 'migmigrations',
+  MigCluster = 'migclusters',
 }


### PR DESCRIPTION
Also adds `yarn prep-remote`, which will create all the requisite objects in a cluster that the installation operator would normally set up ahead of time.

Adds all the CRD object files, and some example crs.