### PR TITLE
Implement the full cluster create/fetch

### DIFF
--- a/config/config.dev.json.example
+++ b/config/config.dev.json.example
@@ -5,4 +5,5 @@
   "oauthClientId": "mig-ui-remote-dev",
   "redirectUri": "http://localhost:9000/auth/callback"
   "namespace": "mig"
+  "configNamespace": "openshift-config"
 }

--- a/config/cr-examples/cluster.yaml
+++ b/config/cr-examples/cluster.yaml
@@ -3,8 +3,6 @@ apiVersion: clusterregistry.k8s.io/v1alpha1
 metadata:
   namespace: mig
   name: my-cluster
-  labels:
-    foo: bar
 spec:
   kubernetesApiEndpoints:
     serverEndpoints:

--- a/config/cr-examples/migassetcollection.yaml
+++ b/config/cr-examples/migassetcollection.yaml
@@ -1,4 +1,4 @@
-apiVersion: migration.openshift.io/v1beta1
+apiVersion: migration.openshift.io/v1alpha1
 kind: MigAssetCollection
 metadata:
   labels:

--- a/config/cr-examples/migcluster.yaml
+++ b/config/cr-examples/migcluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: migration.openshift.io/v1beta1
+apiVersion: migration.openshift.io/v1alpha1
 kind: MigCluster
 metadata:
   labels:

--- a/config/cr-examples/migmigration.yaml
+++ b/config/cr-examples/migmigration.yaml
@@ -1,4 +1,4 @@
-apiVersion: migration.openshift.io/v1beta1
+apiVersion: migration.openshift.io/v1alpha1
 kind: MigMigration
 metadata:
   labels:

--- a/config/cr-examples/migplan.yaml
+++ b/config/cr-examples/migplan.yaml
@@ -1,4 +1,4 @@
-apiVersion: migration.openshift.io/v1beta1
+apiVersion: migration.openshift.io/v1alpha1
 kind: MigPlan
 metadata:
   labels:

--- a/config/cr-examples/migstage.yaml
+++ b/config/cr-examples/migstage.yaml
@@ -1,4 +1,4 @@
-apiVersion: migration.openshift.io/v1beta1
+apiVersion: migration.openshift.io/v1alpha1
 kind: MigStage
 metadata:
   labels:

--- a/config/cr-examples/migstorage.yaml
+++ b/config/cr-examples/migstorage.yaml
@@ -1,4 +1,4 @@
-apiVersion: migration.openshift.io/v1beta1
+apiVersion: migration.openshift.io/v1alpha1
 kind: MigStorage
 metadata:
   labels:

--- a/config/cr-examples/my-cluster.secret.yaml
+++ b/config/cr-examples/my-cluster.secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-cluster
+  namespace: openshift-config
+type: Opaque
+data:
+  hello: Z2FyYmFnZQ==

--- a/config/json-examples/cluster.json
+++ b/config/json-examples/cluster.json
@@ -1,0 +1,23 @@
+{
+    "apiVersion": "clusterregistry.k8s.io/v1alpha1",
+    "kind": "Cluster",
+    "metadata": {
+        "creationTimestamp": "2019-04-02T18:34:17Z",
+        "generation": 1,
+        "name": "my-cluster",
+        "namespace": "mig",
+        "resourceVersion": "867924",
+        "selfLink": "/apis/clusterregistry.k8s.io/v1alpha1/namespaces/mig/clusters/my-cluster",
+        "uid": "ec7cfdd0-5575-11e9-a916-028f25dd2ca2"
+    },
+    "spec": {
+        "kubernetesApiEndpoints": {
+            "serverEndpoints": [
+                {
+                    "clientCIDR": "0.0.0.0",
+                    "serverAddress": ""
+                }
+            ]
+        }
+    }
+}

--- a/config/json-examples/migcluster.json
+++ b/config/json-examples/migcluster.json
@@ -1,0 +1,26 @@
+{
+    "apiVersion": "migration.openshift.io/v1alpha1",
+    "kind": "MigCluster",
+    "metadata": {
+        "creationTimestamp": "2019-04-02T19:09:32Z",
+        "generation": 1,
+        "labels": {
+            "controller-tools.k8s.io": "1.0"
+        },
+        "name": "my-cluster",
+        "namespace": "mig",
+        "resourceVersion": "888505",
+        "selfLink": "/apis/migration.openshift.io/v1alpha1/namespaces/mig/migclusters/my-cluster",
+        "uid": "d8bb1118-557a-11e9-b5e8-028f25dd2ca2"
+    },
+    "spec": {
+        "clusterRef": {
+            "name": "my-cluster",
+            "namespace": "mig"
+        },
+        "serviceAccountSecretRef": {
+            "name": "my-cluster",
+            "namespace": "openshift-config"
+        }
+    }
+}

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -45,6 +45,7 @@ migMeta.oauth = {
   userScope: localConfig.userScope,
 }
 migMeta.namespace = localConfig.namespace;
+migMeta.configNamespace = localConfig.configNamespace;
 
 htmlWebpackPluginOpt.migMeta = migMeta
 

--- a/scripts/create-sa.sh
+++ b/scripts/create-sa.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+oc new-project mig
+oc create sa -n mig mig
+oc adm policy add-cluster-role-to-user cluster-admin system:serviceaccount:mig:mig
+oc sa get-token -n mig mig

--- a/src/app/cluster/components/AddClusterForm.tsx
+++ b/src/app/cluster/components/AddClusterForm.tsx
@@ -107,37 +107,9 @@ const AddClusterForm: any = withFormik({
   },
 
   handleSubmit: (values, formikBag: any) => {
-    const newCluster: IMigCluster = {
-      id: uuidv4(),
-      apiVersion: 'test',
-      kind: 'test',
-      metadata: {
-        creationTimestamp: '',
-        generation: 1,
-        labels: {
-          'controller-ToolsIcon.k8s.io': 1,
-          'migrations.openshift.io/migration-group': 'test',
-        },
-        name: values.name,
-        namespaces: [
-          { name: 'ns1', info: 'info' },
-          { name: 'ns2', info: 'info2' },
-        ],
-        resourceVersion: '',
-        selfLink: '',
-        uid: '',
-      },
-      spec: {
-        clusterAuthSecretRef: {
-          name: values.token,
-          namespace: '',
-        },
-        clusterUrl: values.url,
-      },
-    };
     formikBag.setSubmitting(false);
     formikBag.props.onHandleModalToggle();
-    formikBag.props.onAddItemSubmit('cluster', newCluster);
+    formikBag.props.onAddItemSubmit('cluster', values);
   },
 
   displayName: 'Add Cluster Form',

--- a/src/app/cluster/duck/operations.ts
+++ b/src/app/cluster/duck/operations.ts
@@ -5,7 +5,14 @@ import { IClusterClient } from '../../../client/client';
 import {
   ClusterRegistryResource,
   ClusterRegistryResourceKind,
+  CoreNamespacedResource,
+  CoreNamespacedResourceKind,
 } from '../../../client/resources';
+import {
+  createClusterRegistryObj,
+  createTokenSecret,
+  createMigCluster,
+} from '../../../client/resources/conversions';
 import { MigResource, MigResourceKind } from '../../../client/resources';
 
 const clusterFetchSuccess = Creators.clusterFetchSuccess;
@@ -13,16 +20,39 @@ const addClusterSuccess = Creators.addClusterSuccess;
 const removeClusterSuccess = Creators.removeClusterSuccess;
 const removeClusterFailure = Creators.removeClusterFailure;
 
-const addCluster = cluster => {
+const addCluster = clusterValues => {
   return (dispatch, getState) => {
     try {
-      const { migMeta } = getState();
-      const client: IClusterClient = ClientFactory.hostCluster(getState());
-      const resource = new ClusterRegistryResource(
+      const state = getState();
+      const { migMeta } = state;
+      const client: IClusterClient = ClientFactory.hostCluster(state);
+
+      const clusterReg = createClusterRegistryObj(
+        clusterValues.name, migMeta.namespace, clusterValues.url);
+      const tokenSecret = createTokenSecret(
+        clusterValues.name, migMeta.configNamespace, clusterValues.token);
+      const migCluster = createMigCluster(
+        clusterValues.name, migMeta.namespace, clusterReg, tokenSecret);
+
+      const clusterRegResource = new ClusterRegistryResource(
         ClusterRegistryResourceKind.Cluster, migMeta.namespace);
-      client.create(resource, cluster)
-        .then(res => dispatch(addClusterSuccess(res.data)))
-        .catch(err => AlertCreators.alertError('Failed to add cluster'));
+      const secretResource = new CoreNamespacedResource(
+        CoreNamespacedResourceKind.Secret, migMeta.configNamespace);
+      const migClusterResource = new MigResource(
+        MigResourceKind.MigCluster, migMeta.namespace);
+
+      Promise.all([
+        client.create(clusterRegResource, clusterReg),
+        client.create(secretResource, tokenSecret),
+        client.create(migClusterResource, migCluster),
+      ]).then(arr => {
+        const cluster = arr.reduce((accum, res) => {
+          accum[res.data.kind] = res.data;
+          return accum;
+        }, {});
+        dispatch(addClusterSuccess(cluster));
+      }).catch(err => AlertCreators.alertError('Failed to add cluster'));
+
     } catch (err) {
       dispatch(AlertCreators.alertError(err));
     }
@@ -49,10 +79,19 @@ const fetchClusters = () => {
     try {
       const { migMeta } = getState();
       const client: IClusterClient = ClientFactory.hostCluster(getState());
+
       const resource = new MigResource(
         MigResourceKind.MigCluster, migMeta.namespace);
+
       client.list(resource)
-        .then(res => dispatch(clusterFetchSuccess(res.data.items)))
+        .then(res => {
+          const migClusters = res.data.items;
+          const nonHostClusters = migClusters.filter(c => !c.spec.isHostCluster);
+          Promise.all(fetchMigClusterRefs(client, migMeta, nonHostClusters)).then(refs => {
+            const groupedClusters = groupClusters(migClusters, refs);
+            dispatch(clusterFetchSuccess(groupedClusters));
+          });
+        })
         .catch(err => AlertCreators.alertError('Failed to get clusters'));
     } catch (err) {
       dispatch(AlertCreators.alertError(err));
@@ -65,3 +104,43 @@ export default {
   addCluster,
   removeCluster,
 };
+
+function fetchMigClusterRefs(
+  client: IClusterClient, migMeta, migClusters,
+): Array<Promise<any>> {
+  const refs: Array<Promise<any>> = [];
+
+  migClusters.forEach(cluster => {
+    const clusterRef = cluster.spec.clusterRef;
+    const secretRef = cluster.spec.serviceAccountSecretRef;
+    const clusterRegResource = new ClusterRegistryResource(
+      ClusterRegistryResourceKind.Cluster, clusterRef.namespace);
+    const secretResource = new CoreNamespacedResource(
+      CoreNamespacedResourceKind.Secret, secretRef.namespace);
+    refs.push(client.get(clusterRegResource, clusterRef.name));
+    refs.push(client.get(secretResource, secretRef.name));
+  });
+
+  return refs;
+}
+
+function groupClusters(migClusters: any[], refs: any[]): any[] {
+  return migClusters.map(mc => {
+    const fullCluster  = {
+      'MigCluster': mc,
+    };
+
+    if (!mc.spec.isHostCluster) {
+      fullCluster['Cluster'] = refs.find(i => {
+        return i.data.kind === 'Cluster' &&
+          i.data.metadata.name === mc.metadata.name;
+      }).data;
+      fullCluster['Secret'] = refs.find(i => {
+        return i.data.kind === 'Secret' &&
+          i.data.metadata.name === mc.metadata.name;
+      }).data;
+    }
+
+    return fullCluster;
+  });
+}

--- a/src/app/cluster/duck/reducers.ts
+++ b/src/app/cluster/duck/reducers.ts
@@ -2,59 +2,8 @@ import { Types } from './actions';
 import { createReducer } from 'reduxsauce';
 export const INITIAL_STATE = {
   isFetching: false,
-  clusterList: [
-    {
-      apiVersion: 'migrations.openshift.io/v1beta1',
-      kind: 'MigrationCluster',
-      metadata: {
-        creationTimestamp: '2019-03-13T20:27:51Z',
-        generation: 1,
-        labels: {
-          'controller-tools.k8s.io': '1.0',
-          'migrations.openshift.io/migration-group': 'example',
-        },
-        name: 'my-new-cluster',
-        namespace: 'mig',
-        resourceVersion: '30097',
-        selfLink:
-          '/apis/migrations.openshift.io/v1beta1/namespaces/mig/migrationclusters/my-new-cluster',
-        uid: '797864fb-45ce-11e9-9286-0e070849dc4e',
-      },
-      spec: {
-        clusterAuthSecretRef: {
-          name: 'my-new-cluster-migrationcluster-auth',
-          namespace: 'openshift-config',
-        },
-        clusterUrl: 'https://ocp4.example.com:8443',
-      },
-    },
-    {
-      apiVersion: 'migrations.openshift.io/v1beta1',
-      kind: 'MigrationCluster',
-      metadata: {
-        creationTimestamp: '2019-03-13T20:27:51Z',
-        generation: 1,
-        labels: {
-          'controller-tools.k8s.io': '1.0',
-          'migrations.openshift.io/migration-group': 'example',
-        },
-        name: 'my-old-cluster',
-        namespace: 'mig',
-        resourceVersion: '30096',
-        selfLink:
-          '/apis/migrations.openshift.io/v1beta1/namespaces/mig/migrationclusters/my-old-cluster',
-        uid: '7974889a-45ce-11e9-9286-0e070849dc4e',
-      },
-      spec: {
-        clusterAuthSecretRef: {
-          name: 'my-old-cluster-migrationcluster-auth',
-          namespace: 'openshift-config',
-        },
-        clusterUrl: 'https://ocp3.example.com:8443',
-      },
-    },
-  ],
   clusterSearchText: '',
+  clusterList: [],
 };
 
 export const clusterFetchSuccess = (state = INITIAL_STATE, action) => {

--- a/src/app/common/DynamicModalComponent.tsx
+++ b/src/app/common/DynamicModalComponent.tsx
@@ -62,7 +62,7 @@ class DynamicModalComponent extends React.Component<IProps, {}> {
 export default connect(
   state => ({}),
   dispatch => ({
-    addCluster: cluster => dispatch(clusterOperations.addCluster(cluster)),
+    addCluster: values => dispatch(clusterOperations.addCluster(values)),
     addStorage: values => dispatch(storageOperations.addStorage(values)),
   }),
 )(DynamicModalComponent);

--- a/src/app/home/DetailViewComponent.tsx
+++ b/src/app/home/DetailViewComponent.tsx
@@ -141,7 +141,7 @@ class DetailViewComponent extends Component<IProps, IState> {
 }
 
 function mapStateToProps(state) {
-  const { clusterList } = state.cluster;
+  const clusterList = state.cluster.clusterList.map(c => c.MigCluster);
   const { migStorageList } = state.storage;
   return {
     clusterList,

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,0 +1,68 @@
+export function createTokenSecret(
+  name: string, namespace: string, rawToken: string,
+) {
+  // btoa => to base64, atob => from base64
+  const encodedToken = btoa(rawToken);
+  return {
+    'apiVersion': 'v1',
+    'data': {
+      'token': encodedToken,
+    },
+    'kind': 'Secret',
+    'metadata': {
+      'name': name,
+      'namespace': namespace,
+    },
+    'type': 'Opaque',
+  };
+}
+
+export function tokenFromSecret(secret: any) {
+  return atob(secret.data.token);
+}
+
+export function createClusterRegistryObj(
+  name: string, namespace: string, serverAddress: string,
+) {
+  return {
+    'apiVersion': 'clusterregistry.k8s.io/v1alpha1',
+    'kind': 'Cluster',
+    'metadata': {
+      'name': name,
+      'namespace': namespace,
+    },
+    'spec': {
+      'kubernetesApiEndpoints': {
+        'serverEndpoints': [
+          {
+            'clientCIDR': '0.0.0.0',
+            'serverAddress': serverAddress,
+          },
+        ],
+      },
+    },
+  };
+}
+
+export function createMigCluster(
+  name: string, namespace: string, clusterRegistryObj: any, tokenSecret: any,
+) {
+  return {
+    'apiVersion': 'migration.openshift.io/v1alpha1',
+    'kind': 'MigCluster',
+    'metadata': {
+      'name': name,
+      'namespace': namespace,
+    },
+    'spec': {
+      'clusterRef': {
+        'name': clusterRegistryObj.metadata.name,
+        'namespace': clusterRegistryObj.metadata.namespace,
+      },
+      'serviceAccountSecretRef': {
+        'name': tokenSecret.metadata.name,
+        'namespace': tokenSecret.metadata.namespace,
+      },
+    },
+  };
+}

--- a/src/client/resources/core.ts
+++ b/src/client/resources/core.ts
@@ -1,0 +1,68 @@
+import {
+  NamespacedResource,
+  ClusterResource,
+  IGroupVersionKindPlural,
+} from './common';
+
+export class CoreNamespacedResource extends NamespacedResource {
+  private _gvk: IGroupVersionKindPlural;
+  constructor(kind: CoreNamespacedResourceKind, namespace: string) {
+    super(namespace);
+
+    this._gvk = {
+      group: '',
+      version: 'v1',
+      kindPlural: kind,
+    };
+  }
+  gvk(): IGroupVersionKindPlural {
+    return this._gvk;
+  }
+
+  public listPath(): string {
+    // The core resources live at a unique api path for legacy reasons, and do
+    // not have an API group
+    return [
+      '/api',
+      this.gvk().version,
+      'namespaces',
+      this.namespace,
+      this.gvk().kindPlural,
+    ].join('/');
+  }
+}
+
+export class CoreClusterResource extends ClusterResource {
+  private _gvk: IGroupVersionKindPlural;
+  constructor(kind: CoreClusterResourceKind, namespace: string) {
+    super();
+
+    this._gvk = {
+      group: '',
+      version: 'v1',
+      kindPlural: kind,
+    };
+  }
+  gvk(): IGroupVersionKindPlural {
+    return this._gvk;
+  }
+
+  public listPath(): string {
+    // The core resources live at a unique api path for legacy reasons, and do
+    // not have an API group
+    return [
+      '/api',
+      this.gvk().group,
+      this.gvk().kindPlural,
+    ].join('/');
+  }
+}
+
+export enum CoreNamespacedResourceKind {
+  Pod = 'pods',
+  Secret = 'secrets',
+}
+
+export enum CoreClusterResourceKind {
+  Namespace = 'namespaces',
+}

--- a/src/client/resources/index.ts
+++ b/src/client/resources/index.ts
@@ -9,9 +9,17 @@ export {
 } from './cluster_registry';
 
 export {
+  CoreNamespacedResource,
+  CoreClusterResource,
+  CoreNamespacedResourceKind,
+  CoreClusterResourceKind,
+ } from './core';
+
+export {
   IResource,
   IGroupVersionKindPlural,
   NamespacedResource,
   ClusterResource,
   KubeResource,
  } from './common';
+

--- a/tslint.json
+++ b/tslint.json
@@ -34,6 +34,7 @@
       "quotemark": [true, "single", "jsx-double"],
       "ordered-imports": false,
       "object-literal-key-quotes": false,
+      "no-string-literal": false,
       "variable-name": false
     },
     "jsRules": {


### PR DESCRIPTION
This implements the "full cluster" add and fetch. Cluster objects are actually made up of three separate objects, a `Cluster` object from the cluster-registry project, a `MigCluster` object that represents a cluster for our purposes, and a `Secret` object containing the ServiceAccount's token.