### PR TITLE
Fix alertMessage type handling

### DIFF
--- a/src/app/common/duck/reducers.ts
+++ b/src/app/common/duck/reducers.ts
@@ -7,7 +7,22 @@ export const success = (state = INITIAL_STATE, action) => {
 };
 
 export const failure = (state = INITIAL_STATE, action) => {
-  return { ...state, alertMessage: action.alertMessage, alertType: 'error' };
+  const am = action.alertMessage;
+  let msg;
+
+  // TODO: We really shouldn't accept strings, and Errors. The action creator's
+  // interface should be improved to do compile time type checking and accept
+  // either/or. It's not simple however, because we're currently using reduxsauce.
+  // Need to investigate a way to improve this.
+  if (typeof am === 'string' || am instanceof String) {
+    msg = am;
+  } else if (am instanceof Error) {
+    msg = am.toString();
+  } else {
+    throw new Error('AlertError received an alert message that is not a string, or an Error!');
+  }
+
+  return { ...state, alertMessage: msg, alertType: 'error' };
 };
 export const clear = (state = INITIAL_STATE, action) => {
   return {};


### PR DESCRIPTION
* Alert reducer was written expecting strings, but all the catch
dispatches were feeding it an Error object. This adds some type handling
so that it will accept either a string, or an object. This isn't what we
should accept in the long term, so we need to file an issue to capture
this and hopefully introduce some stronger compile time checks.