### PR TITLE
Fix for broken 'Cancel' with Cluster and Storage forms

### DIFF
--- a/src/app/cluster/components/AddClusterModal/AddClusterForm.tsx
+++ b/src/app/cluster/components/AddClusterModal/AddClusterForm.tsx
@@ -52,6 +52,7 @@ class WrappedAddClusterForm extends React.Component<any, any> {
       setFieldTouched,
       setFieldValue,
       checkConnection,
+      onHandleModalToggle,
     } = this.props;
     const dynamicTokenSecurity = this.state.tokenHidden ? 'disc' : 'inherit';
     const customCss = css`
@@ -131,6 +132,7 @@ class WrappedAddClusterForm extends React.Component<any, any> {
           touched={touched}
           connectionState={connectionState}
           checkConnection={checkConnection}
+          onHandleModalToggle={onHandleModalToggle}
         />
       </Form >
     );

--- a/src/app/common/components/CheckConnection.tsx
+++ b/src/app/common/components/CheckConnection.tsx
@@ -17,6 +17,7 @@ interface IProps {
   errors: any;
   touched: any;
   checkConnection: () => void;
+  onHandleModalToggle: (arg0?: any) => void;
 }
 
 const CheckConnection: React.FunctionComponent<IProps> = ({
@@ -24,6 +25,7 @@ const CheckConnection: React.FunctionComponent<IProps> = ({
   checkConnection,
   errors,
   touched,
+  onHandleModalToggle,
   ...props
 }) => {
 
@@ -66,7 +68,7 @@ const CheckConnection: React.FunctionComponent<IProps> = ({
           <Button
             key="cancel"
             variant="secondary"
-            onClick={() => this.props.onHandleModalToggle(null)}
+            onClick={() => onHandleModalToggle(null)}
           >
             Cancel
           </Button>

--- a/src/app/storage/components/AddStorageModal/AddStorageForm.tsx
+++ b/src/app/storage/components/AddStorageModal/AddStorageForm.tsx
@@ -174,6 +174,7 @@ class WrappedAddStorageForm extends React.Component<any, any> {
           touched={touched}
           connectionState={connectionState}
           checkConnection={checkConnection}
+          onHandleModalToggle={this.props.onHandleModalToggle}
         />
       </Form >
 


### PR DESCRIPTION
I saw the below error when clicking 'Cance'l in 'Add Cluster' and 'Add Repository'

Uncaught TypeError: Cannot read property 'onHandleModalToggle' of undefined
    at onClick (CheckConnection.tsx?d1d8:66)
    at HTMLUnknownElement.callCallback (react-dom.development.js?4646:149)
    at Object.invokeGuardedCallbackDev (react-dom.development.js?4646:199)
    at invokeGuardedCallback (react-dom.development.js?4646:256)
    at invokeGuardedCallbackAndCatchFirstError (react-dom.development.js?4646:270)
    at executeDispatch (react-dom.development.js?4646:561)
    at executeDispatchesInOrder (react-dom.development.js?4646:583)
    at executeDispatchesAndRelease (react-dom.development.js?4646:680)
    at executeDispatchesAndReleaseTopLevel (react-dom.development.js?4646:688)
    at forEachAccumulated (react-dom.development.js?4646:662)

This patch fixes the error, yet not sure if it lines up to the 'proper' fix.
Feel free to close this and address if there is a better way to fix it.

