### PR TITLE
Use the text from Migration Phase as-is for default case

### DIFF
--- a/src/app/home/components/DataList/Plans/MigrationsTable.tsx
+++ b/src/app/home/components/DataList/Plans/MigrationsTable.tsx
@@ -114,8 +114,7 @@ export default class MigrationsTable extends React.Component<any, any> {
             status.progress = null;
             break;
           default:
-            status.phase = 'Something went wrong...';
-            status.progress = null;
+            status.phase = migPhase;
             break;
         }
         return status;


### PR DESCRIPTION
Partially addresses https://github.com/fusor/mig-ui/issues/321

This is intended as a short-term fix to use the default value supplied from the CR