### PR TITLE
Add token expiry and logout fn

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,6 @@
   "baseUrl": "http://localhost:9000",
   "video": false,
   "pluginsFile": false,
-  "supportFile": false
+  "supportFile": false,
+  "chromeWebSecurity": false
 }

--- a/src/app/auth/LoginComponent.tsx
+++ b/src/app/auth/LoginComponent.tsx
@@ -28,7 +28,11 @@ class LoginComponent extends React.Component<IProps> {
     const routerLoc = this.props.router.location;
 
     const freshOauthMeta = !prevProps.auth.oauthMeta && !!oauthMeta;
-    if (freshOauthMeta) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const shouldRefresh = urlParams.get('action') === 'refresh';
+    const handleLogin = freshOauthMeta || shouldRefresh;
+
+    if (handleLogin) {
       const clusterAuth = new ClientOAuth2({
         clientId: migMeta.oauth.clientId,
         clientSecret: migMeta.oauth.clientSecret,

--- a/src/app/auth/duck/operations.ts
+++ b/src/app/auth/duck/operations.ts
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { Creators } from './actions';
 import { push } from 'connected-react-router';
 import commonOperations from '../../common/duck/operations';
+import moment from 'moment';
+
 import {
   isSelfSignedCertError,
   handleSelfSignedCertError,
@@ -35,6 +37,10 @@ const fetchToken = (oauthClient, codeRedirect) => {
     try {
       const result = await oauthClient.code.getToken(codeRedirect);
       const user = result.data;
+      const currentUnixTime = moment().unix();
+      const expiryUnixTime = currentUnixTime + user.expires_in;
+      user.login_time = currentUnixTime;
+      user.expiry_time = expiryUnixTime;
       localStorage.setItem(LS_KEY_CURRENT_USER, JSON.stringify(user));
       dispatch(loginSuccess(user));
       dispatch(push('/'));
@@ -54,8 +60,16 @@ const initFromStorage = () => {
   };
 };
 
+const logoutUser = () => {
+  return dispatch => {
+    localStorage.removeItem(LS_KEY_CURRENT_USER);
+    dispatch(push('/login?action=refresh'));
+  };
+};
+
 export default {
   fetchOauthMeta,
   fetchToken,
   initFromStorage,
+  logoutUser,
 };

--- a/src/client/client.mock.ts
+++ b/src/client/client.mock.ts
@@ -1,11 +1,14 @@
 import { KubeResource } from './resources';
 import KubeStore from './kube_store';
+import { TokenExpiryHandler } from './client';
 
 export class MockClusterClient {
   private name: string;
   private state: object;
   private kube_store: KubeStore;
   private reqTime = 500;
+  private tokenExpiryHandler: TokenExpiryHandler;
+  private tokenExpiryTime: number;
   public apiRoot: string;
 
   constructor(name: string, state: object) {
@@ -13,6 +16,11 @@ export class MockClusterClient {
     this.kube_store = new KubeStore(name);
     this.state = state;
     this.apiRoot = 'http://mock-api.biz';
+  }
+
+  public setTokenExpiryHandler(handler: TokenExpiryHandler, tokenExpiryTime: number) {
+    this.tokenExpiryHandler = handler;
+    this.tokenExpiryTime = tokenExpiryTime;
   }
 
   public list(resource: KubeResource): Promise<any> {

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1,5 +1,8 @@
 import { KubeResource } from './resources/common';
 import axios, { AxiosPromise, AxiosInstance } from 'axios';
+import moment from 'moment';
+
+export type TokenExpiryHandler = (oldToken: object) => void;
 
 export interface IClusterClient {
   list(resource: KubeResource): Promise<any>;
@@ -9,6 +12,14 @@ export interface IClusterClient {
   create(resource: KubeResource, newObject: object): Promise<any>;
   delete(resource: KubeResource, name: string): Promise<any>;
   apiRoot: string;
+  setTokenExpiryHandler: (TokenExpiryHandler, number) => void;
+}
+
+export class ClientTokenExpiredError extends Error {
+  constructor() {
+    super('The api token has expired');
+    Object.setPrototypeOf(this, ClientTokenExpiredError.prototype);
+  }
 }
 
 export class ClusterClient {
@@ -16,6 +27,8 @@ export class ClusterClient {
   public apiRoot: string;
   private requester: AxiosInstance;
   private patchRequester: AxiosInstance;
+  private tokenExpiryHandler: TokenExpiryHandler;
+  private tokenExpiryTime: number;
 
   constructor(apiRoot: string, token: string) {
     this.apiRoot = apiRoot;
@@ -38,22 +51,60 @@ export class ClusterClient {
     });
   }
 
+  public setTokenExpiryHandler(handler: TokenExpiryHandler, tokenExpiryTime: number) {
+    this.tokenExpiryHandler = handler;
+    this.tokenExpiryTime = tokenExpiryTime;
+  }
+
   public list(resource: KubeResource): AxiosPromise<any> {
+    this.checkExpiry();
     return this.requester.get(resource.listPath());
   }
   public get(resource: KubeResource, name: string): AxiosPromise<any> {
+    this.checkExpiry();
     return this.requester.get(resource.namedPath(name));
   }
   public put(resource: KubeResource, name: string, updatedObject: object): AxiosPromise<any> {
+    this.checkExpiry();
     return this.requester.put(resource.namedPath(name), updatedObject);
   }
   public patch(resource: KubeResource, name: string, patch: object): AxiosPromise<any> {
+    this.checkExpiry();
     return this.patchRequester.patch(resource.namedPath(name), patch);
   }
   public create(resource: KubeResource, newObject: object): AxiosPromise<any> {
+    this.checkExpiry();
     return this.requester.post(resource.listPath(), newObject);
   }
   public delete(resource: KubeResource, name: string): AxiosPromise<any> {
+    this.checkExpiry();
     return this.requester.delete(resource.namedPath(name));
+  }
+
+  private checkExpiry() {
+    if(this.isTokenExpired() && this.tokenExpiryHandler) {
+      this.tokenExpiryHandler(this.oldToken());
+    }
+  }
+
+  private isTokenExpired() {
+    const currentUnixTime = moment().unix();
+    const expiredTime = this.tokenExpiryTime;
+    const isExpired = currentUnixTime > expiredTime;
+
+    if(isExpired) {
+      console.warn('Client token appears to be expired:');
+      console.warn(`Current time: ${currentUnixTime}`);
+      console.warn(`Token expiry time: ${expiredTime}`);
+    }
+
+    return isExpired;
+  }
+
+  private oldToken() {
+    return {
+      token: this.token,
+      tokenExpiryTime: this.tokenExpiryTime,
+    };
   }
 }

--- a/src/client/client_factory.mock.ts
+++ b/src/client/client_factory.mock.ts
@@ -1,5 +1,6 @@
 import { MockClusterClient } from './client.mock';
 import mocked_data from './kube_store/mocked_data';
+import { TokenExpiryHandler } from './client';
 
 function determineHostClusterName() {
   return mocked_data['hostMigClusterName'];
@@ -12,4 +13,10 @@ export const ClientFactory = {
   forCluster: (clusterName: string, state: any) => {
     return new MockClusterClient(clusterName, state);
   },
+};
+
+let tokenExpiryHandler = null;
+
+export const setTokenExpiryHandler = (newExpiryHandler: TokenExpiryHandler) => {
+  tokenExpiryHandler = newExpiryHandler;
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,7 @@ import configureStore from './configureStore';
 const { persistor, store } = configureStore();
 import { initMigMeta } from './mig_meta';
 import { authOperations } from './app/auth/duck';
+import { setTokenExpiryHandler } from './client/client_factory';
 
 import Loader from 'react-loader-spinner';
 
@@ -31,6 +32,13 @@ if (!!migMeta) {
   // @ts-ignore
   store.dispatch(authOperations.initFromStorage());
 }
+
+// Configure token expiry behavior
+setTokenExpiryHandler(expiredToken => {
+  // TODO: same thunk issue as above
+  // @ts-ignore
+  store.dispatch(authOperations.logoutUser());
+});
 
 render(
   <Provider store={store}>


### PR DESCRIPTION
Closes #228 
Closes #216

Adds the logout function that should really just be called to take care of #232 and #158.

Some of the motivations for this approach: https://github.com/fusor/mig-ui/issues/228#issuecomment-506033628

Notably:
> We don't want every caller to the client to define token expiry behavior; it should be easy to get a client and the client should default to that behavior

> It's desirable to keep the client decoupled from redux. It's likely we'd need to dispatch some router action to move to a new location (/login), but it's questionable the client should be calling redux directly

Think this achieves that.