### PR TITLE
Fixed status propagaton on failed migrations

### DIFF
--- a/src/app/home/components/DataList/Plans/PlanDataListItem.tsx
+++ b/src/app/home/components/DataList/Plans/PlanDataListItem.tsx
@@ -39,7 +39,7 @@ const PlanDataListItem = ({
               toggleExpanded();
             }}
             isExpanded={isExpanded}
-            id="cluster-toggle"
+            id="plan-toggle"
           />
           <DataListItemCells
             dataListCells={[

--- a/src/app/plan/duck/selectors.ts
+++ b/src/app/plan/duck/selectors.ts
@@ -14,18 +14,17 @@ const getAllPlans = createSelector(
 const getPlansWithStatus = createSelector(
   [planSelector],
   plans => {
-    let hasReadyCondition = null;
-    let hasPlanError = null;
-    let hasMigrationError = null;
-    let hasPrevMigrations = null;
-    let hasRunningMigrations = null;
-    let finalMigrationComplete = null;
-    let hasSucceededMigration = null;
-    let hasSucceededStage = null;
-    let hasClosedCondition = null;
-    let latestType = null;
-
     const plansWithStatus = plans.map(plan => {
+      let hasReadyCondition = null;
+      let hasPlanError = null;
+      let hasMigrationError = null;
+      let hasPrevMigrations = null;
+      let hasRunningMigrations = null;
+      let finalMigrationComplete = null;
+      let hasSucceededMigration = null;
+      let hasSucceededStage = null;
+      let hasClosedCondition = null;
+      let latestType = null;
       if (plan.MigPlan.status) {
         hasClosedCondition = plan.MigPlan.spec.closed;
         hasReadyCondition = !!plan.MigPlan.status.conditions.filter(c => c.type === 'Ready').length;


### PR DESCRIPTION
Here is a case, where the fix makes a change:
Before - last status gets propagated to the failed builds, which has no migrations executed:
![image](https://user-images.githubusercontent.com/32226600/61373387-f7a8ac80-a899-11e9-8815-0d678aabe5bb.png)
Appearance after the fix:
![image (1)](https://user-images.githubusercontent.com/32226600/61373377-ee1f4480-a899-11e9-90be-c73539d9ea19.png)