### PR TITLE
Fix hung pv discovery ensure it times out

### DIFF
--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -1,7 +1,7 @@
 import { race, call, delay, put, take } from 'redux-saga/effects';
 
 import { Creators } from './actions';
-import { alertError } from '../../common/duck/actions'
+import { alertError } from '../../common/duck/actions';
 
 const TicksUntilTimeout = 20;
 
@@ -33,7 +33,7 @@ function* checkPVs(action) {
       // PV discovery timed out, alert and stop polling
       pvsFound = true; // No PVs timed out
       Creators.stopPVPolling();
-      yield put(alertError("Timed out during PV discovery"));
+      yield put(alertError('Timed out during PV discovery'));
       yield put(Creators.pvFetchSuccess());
       yield put({ type: 'STOP_PV_POLLING' });
       break;

--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -1,6 +1,9 @@
 import { race, call, delay, put, take } from 'redux-saga/effects';
 
 import { Creators } from './actions';
+import { alertError } from '../../common/duck/actions'
+
+const TicksUntilTimeout = 20;
 
 function* checkPVs(action) {
   const params = { ...action.params };
@@ -8,7 +11,7 @@ function* checkPVs(action) {
   let tries = 0;
 
   while (!pvsFound) {
-    if (tries < 12) {
+    if (tries < TicksUntilTimeout) {
       tries += 1;
       const plansRes = yield call(params.asyncFetch);
       const pollingStatus = params.callback(plansRes);
@@ -26,6 +29,14 @@ function* checkPVs(action) {
           break;
       }
       yield delay(params.delay);
+    } else {
+      // PV discovery timed out, alert and stop polling
+      pvsFound = true; // No PVs timed out
+      Creators.stopPVPolling();
+      yield put(alertError("Timed out during PV discovery"));
+      yield put(Creators.pvFetchSuccess());
+      yield put({ type: 'STOP_PV_POLLING' });
+      break;
     }
   }
 }


### PR DESCRIPTION
Closes #348 

If pv discovery ever "timed out" (ran past the desired amount of ticks), it would fall into an infinite while loop that would deadlock the UI thread. This at least will prevent a deadlock and alert the user to a timeout.