### PR TITLE
Add MigPlan "delete", "edit" to UI.

### DIFF
--- a/src/app/home/DetailViewComponent.tsx
+++ b/src/app/home/DetailViewComponent.tsx
@@ -92,17 +92,13 @@ class DetailViewComponent extends Component<IProps, IState> {
   handlePlanSubmit = planWizardValues => {
     this.props.putPlan(planWizardValues);
   };
-
-  handlePlanDelete = id => {
-    this.props.removePlan(id);
-  };
-
-  handlePlanEdit = id => {
-    this.props.removePlan(id);
-  };
-
+  
   handleStageTriggered = plan => {
     this.props.runStage(plan);
+  };
+
+  handleDeletePlan = id => {
+    this.props.removePlan(id);
   };
 
   handlePlanPoll = response => {
@@ -138,7 +134,10 @@ class DetailViewComponent extends Component<IProps, IState> {
     const { isWizardOpen } = this.state;
 
     const isAddPlanDisabled = allClusters.length < 2 || allStorage.length < 1;
-    const { handleStageTriggered } = this;
+    const { 
+      handleStageTriggered,
+      handleDeletePlan,
+     } = this;
     return (
       <React.Fragment>
         <DataList aria-label="data-list-main-container">
@@ -157,7 +156,7 @@ class DetailViewComponent extends Component<IProps, IState> {
             isLoading={this.props.isMigrating || this.props.isStaging}
             removeStorage={this.props.removeStorage}
           />
-          <PlanContext.Provider value={{ handleStageTriggered }}>
+          <PlanContext.Provider value={{ handleStageTriggered, handleDeletePlan }}>
             <PlanDataListItem
               planList={plansWithStatus}
               clusterList={allClusters}
@@ -201,6 +200,7 @@ const mapDispatchToProps = dispatch => {
   return {
     removeCluster: id => dispatch(clusterOperations.removeCluster(id)),
     removeStorage: id => dispatch(storageOperations.removeStorage(id)),
+    removePlan: id => dispatch(planOperations.removePlan(id)),
     putPlan: planValues => dispatch(planOperations.putPlan(planValues)),
     runStage: plan => dispatch(planOperations.runStage(plan)),
     updateStageProgress: (plan, progress) =>

--- a/src/app/home/DetailViewComponent.tsx
+++ b/src/app/home/DetailViewComponent.tsx
@@ -93,6 +93,14 @@ class DetailViewComponent extends Component<IProps, IState> {
     this.props.putPlan(planWizardValues);
   };
 
+  handlePlanDelete = id => {
+    this.props.removePlan(id);
+  };
+
+  handlePlanEdit = id => {
+    this.props.removePlan(id);
+  };
+
   handleStageTriggered = plan => {
     this.props.runStage(plan);
   };

--- a/src/app/home/components/DataList/Plans/PlanActions.tsx
+++ b/src/app/home/components/DataList/Plans/PlanActions.tsx
@@ -72,7 +72,8 @@ const PlanActions = ({ plan, isLoading }) => {
           }
           variant="primary"
           onClick={() => {
-            planContext.handlePlanEdit(plan);
+            // planContext.handlePlanEdit(plan.id);
+            alert("Plan Edit onClick()");
           }}
         >
           Edit
@@ -86,7 +87,8 @@ const PlanActions = ({ plan, isLoading }) => {
           }
           variant="primary"
           onClick={() => {
-            planContext.handlePlanDelete(plan);
+            planContext.handleDeletePlan(plan.id);
+            // alert("Plan delete onClick()");
           }}
         >
           Remove

--- a/src/app/home/components/DataList/Plans/PlanActions.tsx
+++ b/src/app/home/components/DataList/Plans/PlanActions.tsx
@@ -62,6 +62,37 @@ const PlanActions = ({ plan, isLoading }) => {
         </Button>
         <MigrateModal plan={plan} isOpen={isOpen} onHandleClose={toggleOpen} />
       </Box>
+      {/* ADDING EDIT AND DELETE */}
+      <Box mx={1}>
+        <Button
+          isDisabled={
+            hasRunningMigrations ||
+            finalMigrationComplete ||
+            isLoading
+          }
+          variant="primary"
+          onClick={() => {
+            planContext.handlePlanEdit(plan);
+          }}
+        >
+          Edit
+        </Button>
+      </Box>
+
+      <Box mx={1}>
+        <Button
+          isDisabled={
+            isLoading
+          }
+          variant="primary"
+          onClick={() => {
+            planContext.handlePlanDelete(plan);
+          }}
+        >
+          Remove
+        </Button>
+      </Box>
+      {/* DONE ADDING EDIT AND DELETE */}
       {isLoading && (
         <Box
           css={css`

--- a/src/app/plan/duck/operations.ts
+++ b/src/app/plan/duck/operations.ts
@@ -31,6 +31,8 @@ const planResultsRequest = Creators.planResultsRequest;
 const addPlanRequest = Creators.addPlanRequest;
 const addPlanSuccess = Creators.addPlanSuccess;
 const addPlanFailure = Creators.addPlanFailure;
+const removePlanSuccess = Creators.removePlanSuccess;
+const removePlanFailure = Creators.removePlanFailure;
 const sourceClusterNamespacesFetchSuccess = Creators.sourceClusterNamespacesFetchSuccess;
 const updatePlanResults = Creators.updatePlanResults;
 const updatePlan = Creators.updatePlan;
@@ -255,7 +257,25 @@ const putPlan = planValues => {
 };
 
 const removePlan = id => {
-  throw new Error('NOT IMPLEMENTED');
+  return async (dispatch, getState) => {
+    try {
+      const state = getState();
+      const { migMeta } = state;
+      const client: IClusterClient = ClientFactory.hostCluster(state);
+
+      const migPlanResource = new MigResource(MigResourceKind.MigPlan, migMeta.namespace);
+
+      const arr = await Promise.all([
+        client.delete(migPlanResource, name),
+      ]);
+
+      dispatch(removePlanSuccess(name));
+      dispatch(commonOperations.alertSuccessTimeout(`Successfully removed plan "${name}"!`));
+    } catch (err) {
+      dispatch(commonOperations.alertErrorTimeout(err));
+      dispatch(removePlanFailure(err));
+    }
+  };
 };
 
 const fetchPlans = () => {


### PR DESCRIPTION
_Work in progress!_

Creating this PR so that I can sanity check the way I've done things so far in adding removal of a plan, and to give myself an easy way to look at the summation of changes made.

Still need to add:
 - Deletion of plan only affecting a single plan (currently deletes all plans instead of just the one you click 'remove' on.
 - Relaunching of the MigPlan wizard with previously provided data filled back in