### PR TITLE
Disable "edit" and "remove" buttons for host cluster

### DIFF
--- a/src/app/home/components/DataList/Clusters/ClusterItem.tsx
+++ b/src/app/home/components/DataList/Clusters/ClusterItem.tsx
@@ -34,6 +34,8 @@ const ClusterItem = ({ cluster, clusterIndex, isLoading, migMeta, removeCluster,
   const [isOpen, toggleOpen] = useOpenModal(false);
   const [isConfirmOpen, toggleConfirmOpen] = useOpenModal(false);
 
+  const isHostCluster = cluster.MigCluster.spec.isHostCluster;
+
   const removeMessage = `Are you sure you want to remove "${clusterName}"`;
 
   const handleRemoveCluster = isConfirmed => {
@@ -65,7 +67,11 @@ const ClusterItem = ({ cluster, clusterIndex, isLoading, migMeta, removeCluster,
             <DataListCell key="actions" width={2}>
               <Flex justifyContent="flex-end">
                 <Box mx={1}>
-                  <Button onClick={toggleOpen} variant="secondary">
+                  <Button 
+                    onClick={toggleOpen} 
+                    variant="secondary"
+                    isDisabled={isHostCluster}
+                  >
                     Edit
                   </Button>
                   <AddClusterModal
@@ -78,7 +84,12 @@ const ClusterItem = ({ cluster, clusterIndex, isLoading, migMeta, removeCluster,
                   />
                 </Box>
                 <Box mx={1}>
-                  <Button onClick={toggleConfirmOpen} variant="danger" key="remove-action">
+                  <Button 
+                    onClick={toggleConfirmOpen} 
+                    variant="danger" 
+                    isDisabled={isHostCluster}
+                    key="remove-action"
+                  >
                     Remove
                   </Button>
                   <ConfirmModal


### PR DESCRIPTION
Prevent deletion and editing of 'host' cluster since there is no way to recreate from the UI and mig-operator does not currently restore this when deleted.

![image](https://user-images.githubusercontent.com/7576968/61970869-ac824e00-afab-11e9-9b5a-0837358cb1f3.png)

mig-operator issue: https://github.com/fusor/mig-operator/issues/22