### PR TITLE
Add current polling state to redux tree

### DIFF
--- a/src/app/cluster/duck/actions.ts
+++ b/src/app/cluster/duck/actions.ts
@@ -10,6 +10,7 @@ const { Creators, Types } = createActions({
   removeClusterSuccess: ['name'],
   setConnectionState: ['connectionState'],
   updateClusterSuccess: ['updatedCluster'],
+  setIsPollingCluster: ['isPolling'],
 });
 
 export { Creators, Types };

--- a/src/app/cluster/duck/reducers.ts
+++ b/src/app/cluster/duck/reducers.ts
@@ -3,6 +3,7 @@ import { createReducer } from 'reduxsauce';
 import ConnectionState from '../../common/connection_state';
 
 export const INITIAL_STATE = {
+  isPolling: false,
   isError: false,
   isFetching: false,
   clusterList: [],
@@ -26,6 +27,9 @@ export const clusterFetchRequest = (state = INITIAL_STATE, action) => {
 };
 export const setConnectionState = (state = INITIAL_STATE, action) => {
   return { ...state, connectionState: action.connectionState };
+};
+export const setIsPollingCluster = (state = INITIAL_STATE, action) => {
+  return { ...state, isPolling: action.isPolling };
 };
 export const addClusterSuccess = (state = INITIAL_STATE, action) => {
   return {
@@ -67,6 +71,7 @@ export const HANDLERS = {
   [Types.UPDATE_CLUSTER_SUCCESS]: updateClusterSuccess,
   [Types.REMOVE_CLUSTER_SUCCESS]: removeClusterSuccess,
   [Types.SET_CONNECTION_STATE]: setConnectionState,
+  [Types.SET_IS_POLLING_CLUSTER]: setIsPollingCluster,
 };
 
 export default createReducer(INITIAL_STATE, HANDLERS);

--- a/src/app/common/duck/sagas.ts
+++ b/src/app/common/duck/sagas.ts
@@ -18,6 +18,8 @@ import {
   alertClear,
 } from './actions';
 
+import { Creators as ClusterActionCreators } from '../../cluster/duck/actions';
+
 export const StatusPollingInterval = 4000;
 
 function* poll(action) {
@@ -53,7 +55,9 @@ function* watchStoragePolling() {
 function* watchClustersPolling() {
   while (true) {
     const action = yield take(startClusterPolling().type);
+    yield put(ClusterActionCreators.setIsPollingCluster(true));
     yield race([call(poll, action), take(stopClusterPolling().type)]);
+    yield put(ClusterActionCreators.setIsPollingCluster(false));
   }
 }
 

--- a/src/app/common/duck/sagas.ts
+++ b/src/app/common/duck/sagas.ts
@@ -19,6 +19,7 @@ import {
 } from './actions';
 
 import { Creators as ClusterActionCreators } from '../../cluster/duck/actions';
+import { Creators as StorageActionCreators } from '../../storage/duck/actions';
 
 export const StatusPollingInterval = 4000;
 
@@ -49,9 +50,12 @@ function* watchDataListPolling() {
 function* watchStoragePolling() {
   while (true) {
     const action = yield take(startStoragePolling().type);
+    yield put(StorageActionCreators.setIsPollingStorage(true));
     yield race([call(poll, action), take(stopStoragePolling().type)]);
+    yield put(StorageActionCreators.setIsPollingStorage(false));
   }
 }
+
 function* watchClustersPolling() {
   while (true) {
     const action = yield take(startClusterPolling().type);

--- a/src/app/storage/duck/actions.ts
+++ b/src/app/storage/duck/actions.ts
@@ -12,6 +12,7 @@ const { Creators, Types } = createActions({
   updateSearchTerm: ['searchTerm'],
   setConnectionState: ['connectionState'],
   updateStorages: ['updatedStorages'],
+  setIsPollingStorage: ['isPolling'],
 });
 
 export { Creators, Types };

--- a/src/app/storage/duck/reducers.ts
+++ b/src/app/storage/duck/reducers.ts
@@ -3,6 +3,7 @@ import { createReducer } from 'reduxsauce';
 import ConnectionState from '../../common/connection_state';
 
 export const INITIAL_STATE = {
+  isPolling: false,
   isFetching: false,
   isError: false,
   migStorageList: [],
@@ -30,6 +31,10 @@ export const migStorageFetchFailure = (state = INITIAL_STATE, action) => {
 
 export const setConnectionState = (state = INITIAL_STATE, action) => {
   return { ...state, connectionState: action.connectionState };
+};
+
+export const setIsPollingStorage = (state = INITIAL_STATE, action) => {
+  return { ...state, isPolling: action.isPolling };
 };
 
 export const addStorageSuccess = (state = INITIAL_STATE, action) => {
@@ -79,6 +84,7 @@ export const HANDLERS = {
   [Types.REMOVE_STORAGE_SUCCESS]: removeStorageSuccess,
   [Types.UPDATE_SEARCH_TERM]: updateSearchTerm,
   [Types.SET_CONNECTION_STATE]: setConnectionState,
+  [Types.SET_IS_POLLING_STORAGE]: setIsPollingStorage,
 };
 
 export default createReducer(INITIAL_STATE, HANDLERS);


### PR DESCRIPTION
Trying to carve out PRs that apply changes on their own that I need for the connection work so I can try and avoid blasting the repo with a massive change. This adds the current cluster/storage polling state to the redux tree so we can make decisions based on that. In particular, I need this to start and stop polling when the modal is open.