### PR TITLE
Use correct field for source pv storageclass

### DIFF
--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -59,7 +59,7 @@ const VolumesTable = (props): any => {
           return {
             name: planVolume.name,
             project: '',
-            storageClass: planVolume.selection.storageClass || '',
+            storageClass: planVolume.storageClass || 'None',
             size: '100 Gi',
             claim: '',
             type: pvAction,


### PR DESCRIPTION
Closes #393

We were simply setting this value from the wrong field on the plan.