### PR TITLE
Revert "Use correct field for source pv storageclass"

### DIFF
--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -59,7 +59,7 @@ const VolumesTable = (props): any => {
           return {
             name: planVolume.name,
             project: '',
-            storageClass: planVolume.storageClass || 'None',
+            storageClass: planVolume.selection.storageClass || '',
             size: '100 Gi',
             claim: '',
             type: pvAction,


### PR DESCRIPTION
Reverts fusor/mig-ui#398

This is breaking storageclass selection for some reason.