### PR TITLE
Use correct source, and selected dest storageclass

### DIFF
--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -44,7 +44,7 @@ const StorageClassTable = (props): any => {
     setStorageClassOptions(scs);
     // Build a pv => assignedStorageClass table, defaulting to the controller suggestion
     const initialAssignedScs = migPlanPvs.reduce((assignedScs, pv) => {
-      assignedScs[pv.name] = scs.find(sc => sc.name === pv.selection.storageClass)
+      assignedScs[pv.name] = scs.find(sc => sc.name === pv.selection.storageClass);
       return assignedScs;
     }, {});
     setPvStorageClassAssignment(initialAssignedScs);

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -59,7 +59,7 @@ const VolumesTable = (props): any => {
           return {
             name: planVolume.name,
             project: '',
-            storageClass: planVolume.selection.storageClass || '',
+            storageClass: planVolume.storageClass || 'None',
             size: '100 Gi',
             claim: '',
             type: pvAction,

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,4 +1,4 @@
-import { pvStorageClassAssignmentKey } from "../../app/plan/components/Wizard/StorageClassTable";
+import { pvStorageClassAssignmentKey } from '../../app/plan/components/Wizard/StorageClassTable';
 
 export function createTokenSecret(name: string, namespace: string, rawToken: string) {
   // btoa => to base64, atob => from base64

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -1,3 +1,5 @@
+import { pvStorageClassAssignmentKey } from "../../app/plan/components/Wizard/StorageClassTable";
+
 export function createTokenSecret(name: string, namespace: string, rawToken: string) {
   // btoa => to base64, atob => from base64
   const encodedToken = btoa(rawToken);
@@ -221,7 +223,7 @@ export function updateMigPlanFromValues(migPlan: any, planValues: any) {
     updatedSpec.persistentVolumes = updatedSpec.persistentVolumes.map(v => {
       const userPv = planValues.persistentVolumes.find(upv => upv.name === v.name);
       v.selection.action = userPv.type;
-      v.selection.storageClass = userPv.storageClass;
+      v.selection.storageClass = planValues[pvStorageClassAssignmentKey][v.name].name;
       return v;
     });
   }


### PR DESCRIPTION
Actually closes #393

Originally though this would be a trivial change, but we had to revert it as it uncovered a deeper problem that revealed the wrong value was being set as the selection (the user's dropdown selection was ignored).

This PR uses the **source** PV in the pv volume table, while also ensuring that the currently selected storage class from the **target** is actually written back to the plan as the user's selected storage class for their target PV.