### PR TITLE
Fixed step reset on plan closure

### DIFF
--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -184,9 +184,7 @@ const WizardComponent = props => {
     }
   };
   const handleClose = () => {
-    if (stepIdReached === stepId.Results) {
-      setStepIdReached(stepId.General);
-    }
+    setStepIdReached(stepId.General);
     props.onHandleClose();
     props.resetForm();
   };


### PR DESCRIPTION
Close action should reset the step to `General` at any moment. Fixes https://github.com/fusor/mig-ui/issues/431