### PR TITLE
Support supplying custom CA bundle for S3 compatible storage

### DIFF
--- a/cypress/integration/storage.spec.js
+++ b/cypress/integration/storage.spec.js
@@ -9,6 +9,7 @@ describe('Storage functionality test', () => {
     const bucketRegion = 'us-east-1';
     const accessKey = 'accessKey';
     const secret = 'secret';
+    const s3CustomCABundle = 'dGVzdA==';
 
     it('adds storage with valid data', () => {
       cy.get('#add-repo-btn').then(() => {
@@ -21,6 +22,7 @@ describe('Storage functionality test', () => {
             cy.get('#bucketRegion').type(bucketRegion);
             cy.get('#accessKey').type(accessKey);
             cy.get('#secret').type(secret);
+            cy.get('#s3CustomCABundle').type(s3CustomCABundle);
             cy.get('#check-connection-btn').click();
             cy.get('#submit-cluster-btn').click();
           });
@@ -38,6 +40,7 @@ describe('Storage functionality test', () => {
             cy.get('#bucketRegion').type(bucketRegion);
             cy.get('#accessKey').type(accessKey);
             cy.get('#secret').type(secret);
+            cy.get('#s3CustomCABundle').type(s3CustomCABundle);
             cy.get('#check-connection-btn').should('be.disabled');
             cy.get('#submit-cluster-btn').should('be.disabled');
           });

--- a/src/app/common/duck/utils.ts
+++ b/src/app/common/duck/utils.ts
@@ -16,6 +16,7 @@ const IPValidator = (value) => {
     }
   }).every(Boolean);
 };
+const Base64Validator = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 
 export const isSelfSignedCertError = (err) => {
   const e = err.toJSON();
@@ -40,10 +41,13 @@ const testDNS1123 = value => DNS1123Validator.test(value);
 
 const testURL = value => URLValidator.test(value) || IPValidator(value);
 
+const testB64 = value => Base64Validator.test(value);
+
 export default {
   testDNS1123,
   DNS1123Error,
   isSelfSignedCertError,
   handleSelfSignedCertError,
   testURL,
+  testB64,
 };

--- a/src/app/home/components/DataList/Storage/StorageItem.tsx
+++ b/src/app/home/components/DataList/Storage/StorageItem.tsx
@@ -25,6 +25,7 @@ const StorageItem = ({ storage, storageIndex, removeStorage, ...props }) => {
   const bucketName = storage.MigStorage.spec.backupStorageConfig.awsBucketName;
   const bucketRegion = storage.MigStorage.spec.backupStorageConfig.awsRegion;
   const s3Url = storage.MigStorage.spec.backupStorageConfig.awsS3Url;
+  const s3CustomCABundle = storage.MigStorage.spec.backupStorageConfig.s3CustomCABundle;
 
   const accessKey =
     typeof storage.Secret === 'undefined'
@@ -140,7 +141,7 @@ const StorageItem = ({ storage, storageIndex, removeStorage, ...props }) => {
             isOpen={isAddEditModalOpen}
             onHandleClose={toggleIsAddEditModalOpen}
             initialStorageValues={{
-              name, bucketName, bucketRegion, accessKey, secret, s3Url,
+              name, bucketName, bucketRegion, accessKey, secret, s3Url, s3CustomCABundle
             }}
           />
           <ConfirmModal

--- a/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -33,6 +33,7 @@ const bucketNameKey = 'bucketName';
 const bucketRegionKey = 'bucketRegion';
 const accessKeyKey = 'accessKey';
 const secretKey = 'secret';
+const s3CustomCABundleKey = 's3CustomCABundle';
 
 const componentTypeStr = 'Repository';
 const currentStatusFn = addEditStatusText(componentTypeStr);
@@ -50,6 +51,7 @@ const valuesHaveUpdate = (values, currentStorage) => {
   const existingBucketName = currentStorage.MigStorage.spec.backupStorageConfig.awsBucketName;
   const existingBucketRegion = currentStorage.MigStorage.spec.backupStorageConfig.awsRegion || '';
   const existingBucketUrl = currentStorage.MigStorage.spec.backupStorageConfig.awsS3Url || '';
+  const existingS3CustomCABundle = currentStorage.MigStorage.spec.backupStorageConfig.s3CustomCABundle || '';
   const existingAccessKeyId = atob(currentStorage.Secret.data['aws-access-key-id']);
   const existingSecretAccessKey = atob(currentStorage.Secret.data['aws-secret-access-key']);
 
@@ -58,6 +60,7 @@ const valuesHaveUpdate = (values, currentStorage) => {
     values.bucketName !== existingBucketName ||
     values.bucketRegion !== existingBucketRegion ||
     values.s3Url !== existingBucketUrl ||
+    values.s3CustomCABundle !== existingS3CustomCABundle ||
     values.accessKey !== existingAccessKeyId ||
     values.secret !== existingSecretAccessKey;
 
@@ -181,6 +184,20 @@ const InnerAddEditStorageForm = (props: IOtherProps & FormikProps<IFormValues>) 
           <FormErrorDiv id="feedback-secret-key">{errors.secret}</FormErrorDiv>
         )}
       </FormGroup>
+      <FormGroup label="S3 Custom CA Bundle" isRequired fieldId={s3CustomCABundleKey}>
+        <TextInput
+          onChange={formikHandleChange}
+          onInput={formikSetFieldTouched(s3CustomCABundleKey)}
+          onBlur={props.handleBlur}
+          value={values.s3CustomCABundle}
+          name={s3CustomCABundleKey}
+          type="text"
+          id="storage-s3-custom-ca-bundle-input"
+        />
+        {errors.s3CustomCABundle && touched.s3CustomCABundle && (
+          <FormErrorDiv id="feedback-s3-custom-ca-bundle">{errors.s3CustomCABundle}</FormErrorDiv>
+        )}
+      </FormGroup>
       <Flex flexDirection="column">
         <Box m="0 0 1em 0 ">
           <Button
@@ -240,6 +257,7 @@ interface IFormValues {
   accessKey: string;
   secret: string;
   s3Url: string;
+  s3CustomCABundle: string;
 }
 interface IOtherProps {
   onAddEditSubmit: any;
@@ -259,6 +277,7 @@ const AddEditStorageForm: any = withFormik({
       accessKey: '',
       secret: '',
       s3Url: '',
+      s3CustomCABundle: '',
     };
 
     if (initialStorageValues) {
@@ -268,6 +287,7 @@ const AddEditStorageForm: any = withFormik({
       values.accessKey = initialStorageValues.accessKey || '';
       values.secret = initialStorageValues.secret || '';
       values.s3Url = initialStorageValues.s3Url || '';
+      values.s3CustomCABundle = initialStorageValues.s3CustomCABundle || '';
     }
 
     return values;
@@ -309,6 +329,10 @@ const AddEditStorageForm: any = withFormik({
 
     if (!values.secret) {
       errors.secret = 'Required';
+    }
+
+    if (!commonUtils.testB64(values.s3CustomCABundle)) {
+      errors.s3CustomCABundle = 'CA bundle must be a valid base64-encoded string.'
     }
 
     return errors;

--- a/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -184,7 +184,7 @@ const InnerAddEditStorageForm = (props: IOtherProps & FormikProps<IFormValues>) 
           <FormErrorDiv id="feedback-secret-key">{errors.secret}</FormErrorDiv>
         )}
       </FormGroup>
-      <FormGroup label="S3 Custom CA Bundle" isRequired fieldId={s3CustomCABundleKey}>
+      <FormGroup label="S3 Custom CA Bundle" fieldId={s3CustomCABundleKey}>
         <TextInput
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(s3CustomCABundleKey)}

--- a/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -332,7 +332,7 @@ const AddEditStorageForm: any = withFormik({
     }
 
     if (!commonUtils.testB64(values.s3CustomCABundle)) {
-      errors.s3CustomCABundle = 'CA bundle must be a valid base64-encoded string.'
+      errors.s3CustomCABundle = 'CA bundle must be a valid base64-encoded string.';
     }
 
     return errors;

--- a/src/app/storage/duck/sagas.ts
+++ b/src/app/storage/duck/sagas.ts
@@ -46,6 +46,7 @@ function* addStorageRequest(action) {
     storageValues.bucketName,
     storageValues.bucketRegion,
     storageValues.s3Url,
+    storageValues.s3CustomCABundle,
     migMeta.namespace,
     storageSecret,
   );
@@ -184,7 +185,9 @@ function* updateStorageRequest(action) {
   const currentS3Url=
     currentStorage.MigStorage.spec.backupStorageConfig.awsS3Url;
   const s3UrlUpdated = storageValues.s3Url !== currentS3Url;
-  const migStorageUpdated = bucketNameUpdated || regionUpdated || s3UrlUpdated;
+  const currentS3CustomCABundle = currentStorage.MigStorage.spec.backupStorageConfig.s3CustomCABundle;
+  const s3CustomCABundleUpdated = storageValues.s3CustomCABundle !== currentS3CustomCABundle;
+  const migStorageUpdated = bucketNameUpdated || regionUpdated || s3UrlUpdated || s3CustomCABundleUpdated;
 
   // Check to see if any fields on the kube secret were updated
   // NOTE: Need to decode the b64 token off a k8s secret
@@ -202,7 +205,7 @@ function* updateStorageRequest(action) {
   const updatePromises = [];
   if (migStorageUpdated) {
     const updatedMigStorage = updateMigStorage(
-      storageValues.bucketName, storageValues.bucketRegion, storageValues.s3Url);
+      storageValues.bucketName, storageValues.bucketRegion, storageValues.s3Url, storageValues.s3CustomCABundle);
     const migStorageResource = new MigResource(
       MigResourceKind.MigStorage, migMeta.namespace);
 

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -88,7 +88,7 @@ export function createMigStorage(
         awsBucketName: bucketName,
         awsRegion: bucketRegion,
         awsS3Url: s3Url,
-        s3CustomCABundle: s3CustomCABundle,
+        s3CustomCABundle,
         credsSecretRef: {
           name: tokenSecret.metadata.name,
           namespace: tokenSecret.metadata.namespace,
@@ -117,7 +117,7 @@ export function updateMigStorage(
         awsBucketName: bucketName,
         awsRegion: bucketRegion,
         awsS3Url: s3Url,
-        s3CustomCABundle: s3CustomCABundle,
+        s3CustomCABundle,
       },
       volumeSnapshotConfig: {
         awsRegion: bucketRegion,

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -70,6 +70,7 @@ export function createMigStorage(
   bucketName: string,
   bucketRegion: string,
   s3Url: string,
+  s3CustomCABundle: string,
   namespace: string,
   tokenSecret: any
 ) {
@@ -87,6 +88,7 @@ export function createMigStorage(
         awsBucketName: bucketName,
         awsRegion: bucketRegion,
         awsS3Url: s3Url,
+        s3CustomCABundle: s3CustomCABundle,
         credsSecretRef: {
           name: tokenSecret.metadata.name,
           namespace: tokenSecret.metadata.namespace,
@@ -107,6 +109,7 @@ export function updateMigStorage(
   bucketName: string,
   bucketRegion: string,
   s3Url: string,
+  s3CustomCABundle: string,
 ) {
   return {
     spec: {
@@ -114,6 +117,7 @@ export function updateMigStorage(
         awsBucketName: bucketName,
         awsRegion: bucketRegion,
         awsS3Url: s3Url,
+        s3CustomCABundle: s3CustomCABundle,
       },
       volumeSnapshotConfig: {
         awsRegion: bucketRegion,


### PR DESCRIPTION
Adds a field for supplying a base64 encoded CA bundle when specifying a storage repository. 

Putting this up as a draft because it will presumably need to change quite a bit due to other currently pending PRs.

Fixes #454

![support-s3-custom-ca-bundle](https://user-images.githubusercontent.com/628956/67983103-5c460800-fbfa-11e9-99fb-9db5ee9756f1.png)

![support-s3-custom-ca-bundle-error png](https://user-images.githubusercontent.com/628956/67982982-1d17b700-fbfa-11e9-8ba8-c8304d43a160.png)
