### PR TITLE
migcluster: add 'insecure' and 'caBundle' fields to add/edit form

### DIFF
--- a/cypress/integration/cluster_spec.js
+++ b/cypress/integration/cluster_spec.js
@@ -7,6 +7,7 @@ describe('Cluster functionality test', () => {
     const clusterName = 'testcluster';
     const url = 'http://example.com';
     const token = '123456';
+    const caBundle = 'dGVzdA==';
 
     it('adds cluster with valid data', () => {
       cy.get('#add-cluster-btn').then(() => {
@@ -17,12 +18,15 @@ describe('Cluster functionality test', () => {
             cy.get('#cluster-name-input').type(clusterName);
             cy.get('#url-input').type(url);
             cy.get('#token-input').type(token);
+            cy.get('#ca-bundle-input').type(caBundle);
+            cy.get('#insecure-input').check();
             cy.get('#check-connection-btn').click();
             cy.get('#submit-cluster-btn').click();
           });
       });
       cy.contains(clusterName);
       cy.contains(url);
+      cy.contains(caBundle);
     });
 
     it('has buttons disabled when input data is missing', () => {
@@ -34,6 +38,8 @@ describe('Cluster functionality test', () => {
             cy.get('#cluster-name-input').should('have.value', '');
             cy.get('#url-input').type(url);
             cy.get('#token-input').type(token);
+            cy.get('#ca-bundle-input').type(caBundle);
+            cy.get('#insecure-input').check();
             cy.get('#check-connection-btn').should('be.disabled');
             cy.get('#submit-cluster-btn').should('be.disabled');
           });

--- a/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -128,36 +128,6 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           <FormErrorDiv id="feedback-token">{errors.token}</FormErrorDiv>
         )}
       </FormGroup>
-      <FormGroup label="Is this an azure cluster?" fieldId={tokenKey}>
-        <Checkbox
-          label="Azure cluster"
-          aria-label="Azure cluster"
-          id="azure-cluster-checkbox"
-          name={isAzureKey}
-          isChecked={values.isAzure}
-          onChange={formikHandleChange}
-          onBlur={handleBlur}
-        />
-      </FormGroup>
-      {
-        values.isAzure &&
-        <FormGroup label="Azure resource group" isRequired fieldId={azureResourceGroupKey}>
-          <TextInput
-            value={values.azureResourceGroup}
-            onChange={formikHandleChange}
-            onInput={formikSetFieldTouched(azureResourceGroupKey)}
-            onBlur={handleBlur}
-            name={azureResourceGroupKey}
-            id="token-input"
-            type="text"
-          />
-          {errors.azureResourceGroup && touched.azureResourceGroup && (
-            <FormErrorDiv id="feedback-token">{errors.azureResourceGroup}</FormErrorDiv>
-          )}
-        </FormGroup>
-
-      }
-
       <FormGroup label="CA Bundle" fieldId={caBundleKey}>
         <TextInput
           onChange={formikHandleChange}
@@ -181,6 +151,33 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           id="insecure-input"
         />
       </FormGroup>
+      <FormGroup label="Is this an azure cluster?" fieldId={tokenKey}>
+        <Checkbox
+          label="Azure cluster"
+          aria-label="Azure cluster"
+          id="azure-cluster-checkbox"
+          name={isAzureKey}
+          isChecked={values.isAzure}
+          onChange={formikHandleChange}
+          onBlur={handleBlur}
+        />
+      </FormGroup>
+      {values.isAzure &&
+        <FormGroup label="Azure resource group" isRequired fieldId={azureResourceGroupKey}>
+          <TextInput
+            value={values.azureResourceGroup}
+            onChange={formikHandleChange}
+            onInput={formikSetFieldTouched(azureResourceGroupKey)}
+            onBlur={handleBlur}
+            name={azureResourceGroupKey}
+            id="token-input"
+            type="text"
+          />
+          {errors.azureResourceGroup && touched.azureResourceGroup && (
+            <FormErrorDiv id="feedback-token">{errors.azureResourceGroup}</FormErrorDiv>
+          )}
+        </FormGroup>}
+
       <Flex flexDirection="column">
         <Box m="0 0 1em 0 ">
           <Button

--- a/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -25,6 +25,7 @@ import {
   isCheckConnectionButtonDisabled,
 } from '../../../common/add_edit_state';
 import ConnectionStatusLabel from '../../../common/components/ConnectionStatusLabel';
+import Thumb from './Thumb';
 
 const nameKey = 'name';
 const urlKey = 'url';
@@ -69,6 +70,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
     handleSubmit,
     handleChange,
     setFieldTouched,
+    setFieldValue,
     handleBlur,
     onClose,
   } = props;
@@ -129,7 +131,20 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         )}
       </FormGroup>
       <FormGroup label="CA Bundle" fieldId={caBundleKey}>
-        <TextInput
+        <div className="form-group">
+          <input
+            id="file"
+            name="file"
+            type="file"
+            onChange={(event) => {
+              setFieldValue(caBundleKey, event.currentTarget.files[0]);
+            }}
+            className="form-control"
+          />
+          <Thumb file={values.caBundle} />
+        </div>
+        {errors.caBundle && touched.caBundle && <FormErrorDiv id="feedback-ca-bundle">{errors.caBundle}</FormErrorDiv>}
+        {/* <TextInput
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(caBundleKey)}
           onBlur={handleBlur}
@@ -138,7 +153,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           type="text"
           id="ca-bundle-input"
         />
-        {errors.caBundle && touched.caBundle && <FormErrorDiv id="feedback-ca-bundle">{errors.caBundle}</FormErrorDiv>}
+        {errors.caBundle && touched.caBundle && <FormErrorDiv id="feedback-ca-bundle">{errors.caBundle}</FormErrorDiv>} */}
       </FormGroup>
       <FormGroup fieldId={insecureKey}>
         <Checkbox

--- a/src/app/cluster/components/AddEditClusterModal/Thumb.tsx
+++ b/src/app/cluster/components/AddEditClusterModal/Thumb.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Formik } from "formik";
+
+class Thumb extends React.Component<any, any> {
+    state = {
+        loading: false,
+        thumb: undefined,
+    };
+
+    componentWillReceiveProps(nextProps) {
+        if (!nextProps.file) { return; }
+
+        this.setState({ loading: true }, () => {
+            let reader = new FileReader();
+
+            reader.onloadend = () => {
+                this.setState({ loading: false, thumb: reader.result });
+            };
+
+            reader.readAsDataURL(nextProps.file);
+        });
+    }
+
+    render() {
+        const { file } = this.props;
+        const { loading, thumb } = this.state;
+
+        if (!file) { return null; }
+
+        if (loading) { return <p>loading...</p>; }
+
+        return (<img src={thumb}
+            alt={file.name}
+            className="img-thumbnail mt-2"
+            height={200}
+            width={200} />);
+    }
+}
+export default Thumb;

--- a/src/app/common/duck/utils.ts
+++ b/src/app/common/duck/utils.ts
@@ -1,6 +1,7 @@
 import { push } from 'connected-react-router';
 import { AuthActions } from '../../auth/duck/actions';
 
+const Base64Validator = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
 const DNS1123Validator = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
 const URLValidator =
   /(http(s)?:\/\/.)(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
@@ -40,10 +41,13 @@ const testDNS1123 = value => DNS1123Validator.test(value);
 
 const testURL = value => URLValidator.test(value) || IPValidator(value);
 
+const testB64 = value => Base64Validator.test(value);
+
 export default {
   testDNS1123,
   DNS1123Error,
   isSelfSignedCertError,
   handleSelfSignedCertError,
   testURL,
+  testB64,
 };

--- a/src/app/home/components/DataList/Clusters/ClusterItem.tsx
+++ b/src/app/home/components/DataList/Clusters/ClusterItem.tsx
@@ -31,6 +31,8 @@ const ClusterItem = ({ cluster, clusterIndex, migMeta, removeCluster, ...props }
   const clusterUrl = cluster.MigCluster.spec.isHostCluster
     ? migMeta.clusterApi
     : cluster.MigCluster.spec.url;
+  const clusterInsecure = cluster.MigCluster.spec.insecure;
+  const clusterCABundle = cluster.MigCluster.spec.caBundle;
 
   const clusterSvcToken =
     !cluster.MigCluster.spec.isHostCluster && cluster.Secret.data.saToken
@@ -143,7 +145,14 @@ const ClusterItem = ({ cluster, clusterIndex, migMeta, removeCluster, ...props }
           <AddEditClusterModal
             isOpen={isAddEditOpen}
             onHandleClose={toggleIsAddEditOpen}
-            initialClusterValues={{ clusterName, clusterUrl, clusterSvcToken, clusterIsAzure }}
+            initialClusterValues={{
+              clusterName,
+              clusterUrl,
+              clusterInsecure,
+              clusterCABundle,
+              clusterSvcToken,
+              clusterIsAzure
+            }}
           />
           <ConfirmModal
             message={removeMessage}

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -36,9 +36,11 @@ export function createMigCluster(
   name: string,
   namespace: string,
   clusterUrl: string,
-  tokenSecret: any,
   isAzure: boolean,
-  azureResourceGroup: string
+  azureResourceGroup: string,
+  insecure: boolean,
+  caBundle: string,
+  tokenSecret: any,
 ) {
   let specObject;
   if (isAzure) {
@@ -46,6 +48,8 @@ export function createMigCluster(
       azureResourceGroup,
       isHostCluster: false,
       url: clusterUrl,
+      insecure,
+      caBundle: caBundle || null,
       serviceAccountSecretRef: {
         name: tokenSecret.metadata.name,
         namespace: tokenSecret.metadata.namespace,
@@ -74,12 +78,16 @@ export function createMigCluster(
   };
 }
 
-export function updateMigClusterUrl(
+export function updateMigCluster(
   clusterUrl: string,
+  insecure: boolean,
+  caBundle: string,
 ) {
   return {
     spec: {
       url: clusterUrl,
+      insecure,
+      caBundle: caBundle || null,
     },
   };
 }

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -59,6 +59,8 @@ export function createMigCluster(
     specObject = {
       isHostCluster: false,
       url: clusterUrl,
+      insecure,
+      caBundle: caBundle || null,
       serviceAccountSecretRef: {
         name: tokenSecret.metadata.name,
         namespace: tokenSecret.metadata.namespace,


### PR DESCRIPTION
Adds an option for disabling SSL verification and an option to provide a base64 encoded caBundle to the migcluster add/edit form. This provides the necessary front end support for https://github.com/fusor/mig-controller/pull/347.

![migcluster-ca-bundle-insecure](https://user-images.githubusercontent.com/628956/68329577-876ba400-009f-11ea-92a8-f6509ceab16e.png)
Fixes #316