### PR TITLE
Plan undo, reconcile driven plan updates.

### DIFF
--- a/src/app/cluster/duck/sagas.ts
+++ b/src/app/cluster/duck/sagas.ts
@@ -9,8 +9,8 @@ import {
 import {
   createTokenSecret,
   createMigCluster,
-  updateTokenSecret,
-  updateMigClusterUrl,
+  patchTokenSecret,
+  patchMigClusterUrl,
 } from '../../../client/resources/conversions';
 
 import { ClusterActions, ClusterActionTypes } from './actions';
@@ -66,12 +66,12 @@ function* addClusterRequest(action) {
         exists;
     }, []);
 
-    if(alreadyExists.length > 0) {
+    if (alreadyExists.length > 0) {
       throw new Error(alreadyExists.reduce((msg, v) => {
         return msg + `- kind: "${v.kind}", name: "${v.name}"`;
       }, 'Some cluster objects already exist '));
     }
-  } catch(err) {
+  } catch (err) {
     console.error(err.message);
     yield put(ClusterActions.setClusterAddEditStatus(createAddEditStatusWithMeta(
       AddEditState.Critical,
@@ -99,7 +99,7 @@ function* addClusterRequest(action) {
       clusterAddResults.find(res => res.state === 'rejected') &&
       clusterAddResults.find(res => res.state === 'fulfilled');
 
-    if(isRollbackRequired) {
+    if (isRollbackRequired) {
       const kindToResourceMap = {
         MigCluster: migClusterResource,
         Secret: secretResource,
@@ -118,7 +118,7 @@ function* addClusterRequest(action) {
 
       // Something went wrong with rollback, not much we can do at this point
       // except inform the user about what's gone wrong so they can take manual action
-      if(rollbackResults.find(res => res.state === 'rejected')) {
+      if (rollbackResults.find(res => res.state === 'rejected')) {
         throw new Error(rollbackResults.reduce((msg, r) => {
           const kind = r.reason.request.response.kind;
           const name = r.reason.request.response.details.name;
@@ -181,7 +181,7 @@ function* updateClusterRequest(action) {
 
   const updatePromises = [];
   if (urlUpdated) {
-    const urlUpdatePatch = updateMigClusterUrl(clusterValues.url);
+    const urlUpdatePatch = patchMigClusterUrl(clusterValues.url);
     const migClusterResource = new MigResource(
       MigResourceKind.MigCluster, migMeta.namespace);
 
@@ -191,7 +191,7 @@ function* updateClusterRequest(action) {
   }
 
   if (tokenUpdated) {
-    const newTokenSecret = updateTokenSecret(clusterValues.token);
+    const newTokenSecret = patchTokenSecret(clusterValues.token);
     const secretResource = new CoreNamespacedResource(
       CoreNamespacedResourceKind.Secret,
       migMeta.configNamespace,

--- a/src/app/plan/components/Wizard/NameSpaceTable.tsx
+++ b/src/app/plan/components/Wizard/NameSpaceTable.tsx
@@ -20,7 +20,7 @@ interface INamespaceTableProps {
 
 const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
   const { setFieldValue, sourceClusterNamespaces, values } = props;
-  const [checkedNamespaceRows, setCheckedNamespaceRows] = useState({});
+  const [checkedNamespaceRows, setCheckedNamespaceRows] = useState(sourceClusterNamespaces.map(ns => ns.metadata.uid));
   const [selectAll, setSelectAll] = useState(0);
 
   useEffect(() => {
@@ -28,7 +28,7 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
       const keys = Object.keys(checkedNamespaceRows);
 
       for (const key of keys) {
-        if (item.metadata.uid === key) {
+        if (item.metadata.uid === key && checkedNamespaceRows[key]) {
           return item;
         }
       }
@@ -69,10 +69,6 @@ const NamespaceTable: React.FunctionComponent<INamespaceTableProps> = props => {
     setSelectAll(2);
   };
 
-
-  const StyledTextContent = styled(TextContent)`
-      margin: 1em 0 1em 0;
-    `;
 
   if (values.sourceCluster !== null) {
     return (

--- a/src/app/plan/components/Wizard/ResultsStep.tsx
+++ b/src/app/plan/components/Wizard/ResultsStep.tsx
@@ -25,12 +25,21 @@ interface IProps {
   currentPlan: any;
   currentPlanStatus: ICurrentPlanStatus;
   isPollingStatus: boolean;
+  isReconciling: boolean;
 }
 
 
 
 const ResultsStep: React.FunctionComponent<IProps> = props => {
-  const { values, currentPlan, currentPlanStatus, isPollingStatus, startPlanStatusPolling, onClose } = props;
+  const {
+    values,
+    currentPlan,
+    currentPlanStatus,
+    isPollingStatus,
+    isReconciling,
+    startPlanStatusPolling,
+    onClose } = props;
+
   const handlePollRestart = () => {
     startPlanStatusPolling(values.planName);
   };
@@ -172,7 +181,9 @@ const ResultsStep: React.FunctionComponent<IProps> = props => {
             </Button>
           <Button
             style={{ marginLeft: '10px', marginRight: '10px' }}
-            onClick={handlePollRestart} disabled={isPollingStatus} variant="secondary" >Check Connection</Button>
+            onClick={handlePollRestart}
+            disabled={isPollingStatus || isReconciling}
+            variant="secondary" >Check Connection</Button>
           <Tooltip
             position={TooltipPosition.top}
             content={<div>

--- a/src/app/plan/components/Wizard/ResultsStep.tsx
+++ b/src/app/plan/components/Wizard/ResultsStep.tsx
@@ -1,6 +1,6 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from '@emotion/styled';
 import { Box } from '@rebass/emotion';
 import { RedoIcon } from '@patternfly/react-icons';
@@ -44,16 +44,12 @@ const ResultsStep: React.FunctionComponent<IProps> = props => {
     startPlanStatusPolling(values.planName);
   };
 
-  function HeaderIcon({ state }) {
-    const StyledIcon = styled(RedoIcon)`
-      height: 1.3em;
-      width: 1.3em;
-    `;
-    const StyledLoaderWrapper = styled.span`
-      display: inline-block;
-      margin-right: 0.75rem;
-    `;
+  // Update status on component load
+  useEffect(() => {
+    handlePollRestart();
+  }, [isReconciling]);
 
+  function HeaderIcon({ state }) {
     switch (state) {
       case CurrentPlanState.Pending:
         return <Spinner size="xl" />;

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -1,7 +1,5 @@
 /** @jsx jsx */
 import { jsx } from '@emotion/core';
-import React from 'react';
-import { Box } from '@rebass/emotion';
 import {
   Grid,
   GridItem,
@@ -10,12 +8,8 @@ import {
   TextVariants
 } from '@patternfly/react-core';
 import StorageClassTable from './StorageClassTable';
-import styled from '@emotion/styled';
 const StorageClassForm = props => {
-  const { setFieldValue, values, currentPlan, clusterList, isFetchingPVList } = props;
-  const StyledTextContent = styled(TextContent)`
-    margin: 1em 0 1em 0;
-  `;
+  const { setFieldValue, values, currentPlan, clusterList, isFetchingPVList, isReconciling } = props;
   return (
     <Grid gutter="md">
       <GridItem>
@@ -28,6 +22,7 @@ const StorageClassForm = props => {
       <GridItem>
         <StorageClassTable
           isFetchingPVList={isFetchingPVList}
+          isReconciling={isReconciling}
           setFieldValue={setFieldValue}
           values={values}
           currentPlan={currentPlan}

--- a/src/app/plan/components/Wizard/StorageClassForm.tsx
+++ b/src/app/plan/components/Wizard/StorageClassForm.tsx
@@ -9,7 +9,7 @@ import {
 } from '@patternfly/react-core';
 import StorageClassTable from './StorageClassTable';
 const StorageClassForm = props => {
-  const { setFieldValue, values, currentPlan, clusterList, isFetchingPVList, isReconciling } = props;
+  const { setFieldValue, values, currentPlan, clusterList, isReconciling } = props;
   return (
     <Grid gutter="md">
       <GridItem>
@@ -21,7 +21,6 @@ const StorageClassForm = props => {
       </GridItem>
       <GridItem>
         <StorageClassTable
-          isFetchingPVList={isFetchingPVList}
           isReconciling={isReconciling}
           setFieldValue={setFieldValue}
           values={values}

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -17,7 +17,7 @@ import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 export const pvStorageClassAssignmentKey = 'pvStorageClassAssignment';
 
 const StorageClassTable = (props): any => {
-  const { currentPlan, clusterList, values, isFetchingPVList, isReconciling } = props;
+  const { currentPlan, clusterList, values, isReconciling } = props;
   const migPlanPvs = currentPlan.spec.persistentVolumes;
   const [rows, setRows] = useState([]);
   const [storageClassOptions, setStorageClassOptions] = useState([]);
@@ -60,9 +60,9 @@ const StorageClassTable = (props): any => {
     if (values.persistentVolumes.length) {
       setRows(values.persistentVolumes.filter(v => v.type === 'copy'));
     }
-  }, [isFetchingPVList, isReconciling]); // Only re-run the effect if fetching value changes
+  }, [isReconciling]); // Only re-run the effect if plan version changes
 
-  if (isFetchingPVList || isReconciling) {
+  if (isReconciling) {
     return (
       <Bullseye>
         <EmptyState variant="small">

--- a/src/app/plan/components/Wizard/StorageClassTable.tsx
+++ b/src/app/plan/components/Wizard/StorageClassTable.tsx
@@ -17,7 +17,7 @@ import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 export const pvStorageClassAssignmentKey = 'pvStorageClassAssignment';
 
 const StorageClassTable = (props): any => {
-  const { currentPlan, clusterList, values, isFetchingPVList } = props;
+  const { currentPlan, clusterList, values, isFetchingPVList, isReconciling } = props;
   const migPlanPvs = currentPlan.spec.persistentVolumes;
   const [rows, setRows] = useState([]);
   const [storageClassOptions, setStorageClassOptions] = useState([]);
@@ -60,9 +60,9 @@ const StorageClassTable = (props): any => {
     if (values.persistentVolumes.length) {
       setRows(values.persistentVolumes.filter(v => v.type === 'copy'));
     }
-  }, [isFetchingPVList]); // Only re-run the effect if fetching value changes
+  }, [isFetchingPVList, isReconciling]); // Only re-run the effect if fetching value changes
 
-  if (isFetchingPVList) {
+  if (isFetchingPVList || isReconciling) {
     return (
       <Bullseye>
         <EmptyState variant="small">

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -14,11 +14,9 @@ const VolumesForm = props => {
     setFieldValue,
     values,
     isPVError,
-    isFetchingPVList,
     currentPlan,
     getPVResourcesRequest,
     pvResourceList,
-    isFetchingPVResources,
     isReconciling,
   } = props;
 
@@ -34,13 +32,11 @@ const VolumesForm = props => {
       <GridItem>
         <VolumesTable
           isPVError={isPVError}
-          isFetchingPVList={isFetchingPVList}
           setFieldValue={setFieldValue}
           values={values}
           currentPlan={currentPlan}
           getPVResourcesRequest={getPVResourcesRequest}
           pvResourceList={pvResourceList}
-          isFetchingPVResources={isFetchingPVResources}
           isReconciling={isReconciling}
         />
       </GridItem>

--- a/src/app/plan/components/Wizard/VolumesForm.tsx
+++ b/src/app/plan/components/Wizard/VolumesForm.tsx
@@ -18,7 +18,8 @@ const VolumesForm = props => {
     currentPlan,
     getPVResourcesRequest,
     pvResourceList,
-    isFetchingPVResources
+    isFetchingPVResources,
+    isReconciling,
   } = props;
 
   return (
@@ -40,8 +41,9 @@ const VolumesForm = props => {
           getPVResourcesRequest={getPVResourcesRequest}
           pvResourceList={pvResourceList}
           isFetchingPVResources={isFetchingPVResources}
+          isReconciling={isReconciling}
         />
-       </GridItem>
+      </GridItem>
     </Grid>
   );
 };

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -36,7 +36,8 @@ const VolumesTable = (props): any => {
     isFetchingPVList,
     getPVResourcesRequest,
     isFetchingPVResources,
-    pvResourceList
+    pvResourceList,
+    isReconciling,
   } = props;
   const [rows, setRows] = useState([]);
 
@@ -101,7 +102,7 @@ const VolumesTable = (props): any => {
       setFieldValue('persistentVolumes', mappedPVs);
       setRows(mappedPVs);
     }
-  }, [isFetchingPVList]); // Only re-run the effect if fetching value changes
+  }, [isFetchingPVList, isReconciling]); // Only re-run the effect if fetching value changes
 
   const StyledTextContent = styled(TextContent)`
     margin: 1em 0 1em 0;
@@ -129,7 +130,7 @@ const VolumesTable = (props): any => {
       </Box>
     );
   }
-  if (isFetchingPVList) {
+  if (isFetchingPVList || isReconciling) {
     return (
       <Bullseye>
         <EmptyState variant="large">
@@ -141,7 +142,7 @@ const VolumesTable = (props): any => {
           </Title>
         </EmptyState>
       </Bullseye>
-     );
+    );
   }
 
   return (

--- a/src/app/plan/components/Wizard/VolumesTable.tsx
+++ b/src/app/plan/components/Wizard/VolumesTable.tsx
@@ -33,9 +33,7 @@ const VolumesTable = (props): any => {
     currentPlan,
     values,
     isPVError,
-    isFetchingPVList,
     getPVResourcesRequest,
-    isFetchingPVResources,
     pvResourceList,
     isReconciling,
   } = props;
@@ -116,7 +114,7 @@ const VolumesTable = (props): any => {
     );
   }
 
-  if (isFetchingPVList || isReconciling) {
+  if (isReconciling) {
     return (
       <Bullseye>
         <EmptyState variant="large">
@@ -290,7 +288,7 @@ const VolumesTable = (props): any => {
               >
                 <Flex>
                   <Box>
-                    <Button isDisabled={isFetchingPVResources} variant="link" icon={<BlueprintIcon />}>
+                    <Button isDisabled={isReconciling} variant="link" icon={<BlueprintIcon />}>
                       View JSON
                     </Button>
                   </Box>

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -38,6 +38,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     getPVResourcesRequest,
     startPlanStatusPolling,
     planUpdateRequest,
+    isReconciling,
     isPollingStorage,
     isPollingClusters,
     isPollingPlans,
@@ -55,6 +56,8 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     MigrationTarget,
     Results,
   }
+
+  const secondarySteps = [stepId.StorageClass];
 
   useEffect(() => {
     if (props.isOpen && (isPollingPlans || isPollingClusters || isPollingStorage)) {
@@ -124,7 +127,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
             isFetchingPVResources={isFetchingPVResources}
           />
         ),
-        enableNext: !isFetchingPVList && !isPVError,
+        enableNext: !isFetchingPVList && !isPVError && !isReconciling,
         canJumpTo: stepIdReached >= stepId.PersistentVolumes,
       },
       {
@@ -158,6 +161,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
             currentPlan={currentPlan}
             currentPlanStatus={currentPlanStatus}
             isPollingStatus={isPollingStatus}
+            isReconciling={isReconciling}
             startPlanStatusPolling={startPlanStatusPolling}
             onClose={handleClose}
           />
@@ -174,6 +178,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     isFetchingPVList,
     isPollingStatus,
     isFetchingNamespaceList,
+    isReconciling,
     pvResourceList,
     errors,
     touched
@@ -199,12 +204,17 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
         });
       }
     }
-    if (curr.id === stepId.Results) {
-      //update plan & start status polling on results page
+
+    if (currentPlan && prev.prevId < curr.id && !secondarySteps.includes(curr.id)) {
       planUpdateRequest(props.values);
+    }
+
+    //start status polling on results page
+    if (curr.id === stepId.Results) {
       startPlanStatusPolling(props.values.planName);
     }
   };
+
   const handleClose = () => {
     onHandleWizardModalClose();
     setStepIdReached(stepId.General);

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -28,7 +28,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     currentPlanStatus,
     storageList,
     isOpen,
-    isFetchingPVList,
     isFetchingNamespaceList,
     isPVError,
     isPollingStatus,
@@ -64,7 +63,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
   });
 
   useEffect(() => {
-    const isUpdating = isReconciling || isFetchingPVList;
     const steps = [
       {
         id: stepId.General,
@@ -79,6 +77,7 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
             setFieldTouched={setFieldTouched}
           />
         ),
+        canJumpTo: !isReconciling,
         enableNext: !errors.planName && touched.planName === true,
       },
       {
@@ -108,9 +107,9 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
           !errors.sourceCluster &&
           touched.sourceCluster === true &&
           !errors.selectedNamespaces,
-        canJumpTo: stepIdReached >= stepId.MigrationSource && !isUpdating,
-        hideCancelButton: isUpdating,
-        hideBackButton: isUpdating,
+        canJumpTo: stepIdReached >= stepId.MigrationSource && !isReconciling,
+        hideCancelButton: isReconciling,
+        hideBackButton: isReconciling,
       },
       {
         id: stepId.PersistentVolumes,
@@ -121,7 +120,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
             setFieldValue={setFieldValue}
             setFieldTouched={setFieldTouched}
             currentPlan={currentPlan}
-            isFetchingPVList={isFetchingPVList}
             isPVError={isPVError}
             getPVResourcesRequest={getPVResourcesRequest}
             pvResourceList={pvResourceList}
@@ -129,10 +127,10 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
             isReconciling={isReconciling}
           />
         ),
-        enableNext: !isFetchingPVList && !isPVError && !isReconciling,
-        canJumpTo: stepIdReached >= stepId.PersistentVolumes && !isUpdating,
-        hideCancelButton: isUpdating,
-        hideBackButton: isUpdating,
+        enableNext: !isPVError && !isReconciling,
+        canJumpTo: stepIdReached >= stepId.PersistentVolumes && !isReconciling,
+        hideCancelButton: isReconciling,
+        hideBackButton: isReconciling,
       },
       {
         id: stepId.StorageClass,
@@ -147,14 +145,13 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
             setFieldValue={setFieldValue}
             setFieldTouched={setFieldTouched}
             currentPlan={currentPlan}
-            isFetchingPVList={isFetchingPVList}
             isReconciling={isReconciling}
             clusterList={clusterList}
           />
         ),
-        canJumpTo: stepIdReached >= stepId.StorageClass && !isUpdating,
-        hideCancelButton: isUpdating,
-        hideBackButton: isUpdating,
+        canJumpTo: stepIdReached >= stepId.StorageClass && !isReconciling,
+        hideCancelButton: isReconciling,
+        hideBackButton: isReconciling,
         nextButtonText: 'Finish',
       },
       {
@@ -182,7 +179,6 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     currentPlan,
     values,
     isPVError,
-    isFetchingPVList,
     isPollingStatus,
     isFetchingNamespaceList,
     isReconciling,

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -13,6 +13,7 @@ export interface IFormValues {
   selectedNamespaces: any[];
 }
 export interface IOtherProps {
+  isReconciling: boolean;
   clusterList: any[];
   planList: any[];
   storageList: any[];
@@ -100,6 +101,7 @@ const mapStateToProps = state => {
     selectedNamespaces: [],
     selectedStorage: '',
     persistentVolumes: [],
+    isReconciling: state.plan.isReconciling,
     isPollingPlans: state.plan.isPolling,
     isPollingClusters: state.cluster.isPolling,
     isPollingStorage: state.storage.isPolling,
@@ -120,7 +122,6 @@ const mapDispatchToProps = dispatch => {
     fetchNamespacesForCluster: clusterName => {
       dispatch(planOperations.fetchNamespacesForCluster(clusterName));
     },
-    pvFetchRequest: () => dispatch(planOperations.pvFetchRequest()),
     getPVResourcesRequest: (pvList, clusterName) => dispatch(PlanActions.getPVResourcesRequest(pvList, clusterName)),
     startPlanStatusPolling: (planName) => dispatch(PlanActions.startPlanStatusPolling(planName)),
     planUpdateRequest: (values) => dispatch(PlanActions.planUpdateRequest(values)),

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -17,7 +17,6 @@ export interface IOtherProps {
   clusterList: any[];
   planList: any[];
   storageList: any[];
-  isFetchingPVList: boolean;
   isPollingStatus: boolean;
   isPVError: boolean;
   isCheckingPlanStatus: boolean;
@@ -108,7 +107,6 @@ const mapStateToProps = state => {
     isPollingStatus: state.plan.isPollingStatus,
     isFetchingNamespaceList: state.plan.isFetchingNamespaceList,
     sourceClusterNamespaces: filteredSourceClusterNamespaces,
-    isFetchingPVList: state.plan.isFetchingPVList,
     isFetchingPVResources: state.plan.isFetchingPVResources,
     isPVError: state.plan.isPVError,
     currentPlan: planSelectors.getCurrentPlan(state),

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -31,10 +31,10 @@ export interface IOtherProps {
   currentPlanStatus: any;
   startPlanStatusPolling: (planName) => void;
   planUpdateRequest: (values) => void;
+  planCreateRequest: (values) => void;
   resetCurrentPlan: () => void;
   fetchNamespacesForCluster: () => void;
   getPVResourcesRequest: () => void;
-  addPlan: (planValues) => void;
   sourceClusterNamespaces: any[];
   pvResourceList: any[];
   onHandleWizardModalClose: () => void;
@@ -118,13 +118,13 @@ const mapStateToProps = state => {
 };
 const mapDispatchToProps = dispatch => {
   return {
-    addPlan: plan => dispatch(planOperations.addPlan(plan)),
     fetchNamespacesForCluster: clusterName => {
       dispatch(planOperations.fetchNamespacesForCluster(clusterName));
     },
     getPVResourcesRequest: (pvList, clusterName) => dispatch(PlanActions.getPVResourcesRequest(pvList, clusterName)),
     startPlanStatusPolling: (planName) => dispatch(PlanActions.startPlanStatusPolling(planName)),
     planUpdateRequest: (values) => dispatch(PlanActions.planUpdateRequest(values)),
+    planCreateRequest: (values) => dispatch(PlanActions.planCreateRequest(values)),
     resetCurrentPlan: () => dispatch(PlanActions.resetCurrentPlan()),
   };
 };

--- a/src/app/plan/duck/actions.ts
+++ b/src/app/plan/duck/actions.ts
@@ -34,6 +34,8 @@ export const PlanActionTypes = {
   PLAN_RESULTS_REQUEST: 'PLAN_RESULTS_REQUEST',
   INIT_STAGE: 'INIT_STAGE',
   INIT_MIGRATION: 'INIT_MIGRATION',
+  PLAN_RECONCILE_POLL: 'PLAN_RECONCILE_POLL',
+  PLAN_RECONCILE_POLL_STOP: 'PLAN_RECONCILE_POLL_STOP',
   PLAN_CLOSE_AND_DELETE_REQUEST: 'PLAN_CLOSE_AND_DELETE_REQUEST',
   PLAN_CLOSE_AND_DELETE_SUCCESS: 'PLAN_CLOSE_AND_DELETE_SUCCESS',
   PLAN_CLOSE_AND_DELETE_FAILURE: 'PLAN_CLOSE_AND_DELETE_FAILURE',
@@ -192,6 +194,15 @@ const initMigration = (planName: string) => ({
   planName,
 });
 
+const planReconcilePolling = (planValues) => ({
+  type: PlanActionTypes.PLAN_RECONCILE_POLL,
+  planValues,
+});
+
+const stopPlanReconcilePolling = () => ({
+  type: PlanActionTypes.PLAN_RECONCILE_POLL_STOP,
+});
+
 const planCloseAndDeleteRequest = (planName: string) => ({
   type: PlanActionTypes.PLAN_CLOSE_AND_DELETE_REQUEST,
   planName,
@@ -315,6 +326,8 @@ export const PlanActions = {
   addPlanRequest,
   initStage,
   initMigration,
+  planReconcilePolling,
+  stopPlanReconcilePolling,
   planCloseAndDeleteRequest,
   planCloseAndDeleteSuccess,
   planCloseAndDeleteFailure,

--- a/src/app/plan/duck/actions.ts
+++ b/src/app/plan/duck/actions.ts
@@ -3,8 +3,9 @@ import { ICurrentPlanStatus } from './reducers';
 
 export const PlanActionTypes = {
   UPDATE_PLANS: 'UPDATE_PLANS',
-  ADD_PLAN_SUCCESS: 'ADD_PLAN_SUCCESS',
-  ADD_PLAN_FAILURE: 'ADD_PLAN_FAILURE',
+  PLAN_CREATE_REQUEST: 'PLAN_CREATE_REQUEST',
+  PLAN_CREATE_SUCCESS: 'PLAN_CREATE_SUCCESS',
+  PLAN_CREATE_FAILURE: 'PLAN_CREATE_FAILURE',
   UPDATE_PLAN_RESULTS: 'UPDATE_PLAN_RESULTS',
   REMOVE_PLAN_SUCCESS: 'REMOVE_PLAN_SUCCESS',
   UPDATE_STAGE_PROGRESS: 'UPDATE_STAGE_PROGRESS',
@@ -21,13 +22,11 @@ export const PlanActionTypes = {
   NAMESPACE_FETCH_REQUEST: 'NAMESPACE_FETCH_REQUEST',
   NAMESPACE_FETCH_SUCCESS: 'NAMESPACE_FETCH_SUCCESS',
   NAMESPACE_FETCH_FAILURE: 'NAMESPACE_FETCH_FAILURE',
-  PV_FETCH_REQUEST: 'PV_FETCH_REQUEST',
   PV_FETCH_FAILURE: 'PV_FETCH_FAILURE',
   PV_FETCH_SUCCESS: 'PV_FETCH_SUCCESS',
   SOURCE_CLUSTER_NAMESPACES_FETCH_SUCCESS: 'SOURCE_CLUSTER_NAMESPACES_FETCH_SUCCESS',
   START_PV_POLLING: 'START_PV_POLLING',
   STOP_PV_POLLING: 'STOP_PV_POLLING',
-  ADD_PLAN_REQUEST: 'ADD_PLAN_REQUEST',
   PLAN_UPDATE_REQUEST: 'PLAN_UPDATE_REQUEST',
   PLAN_UPDATE_SUCCESS: 'PLAN_UPDATE_SUCCESS',
   PLAN_UPDATE_FAILURE: 'PLAN_UPDATE_FAILURE',
@@ -59,16 +58,6 @@ export const PlanActionTypes = {
 const updatePlans = (updatedPlans: IMigPlan[]) => ({
   type: PlanActionTypes.UPDATE_PLANS,
   updatedPlans,
-});
-
-const addPlanSuccess = (newPlan: IMigPlan) => ({
-  type: PlanActionTypes.ADD_PLAN_SUCCESS,
-  newPlan,
-});
-
-const addPlanFailure = (error) => ({
-  type: PlanActionTypes.ADD_PLAN_FAILURE,
-  error,
 });
 
 const removePlanSuccess = (id) => ({
@@ -126,10 +115,6 @@ const migPlanFetchFailure = () => ({
   type: PlanActionTypes.MIG_PLAN_FETCH_FAILURE,
 });
 
-const pvFetchRequest = () => ({
-  type: PlanActionTypes.PV_FETCH_REQUEST,
-});
-
 const pvFetchFailure = () => ({
   type: PlanActionTypes.PV_FETCH_FAILURE,
 });
@@ -157,9 +142,9 @@ const namespaceFetchFailure = (err) => ({
   err,
 });
 
-const startPVPolling = (params) => ({
+const startPVPolling = (planName: string) => ({
   type: PlanActionTypes.START_PV_POLLING,
-  params,
+  planName,
 });
 
 const stopPVPolling = () => ({
@@ -180,9 +165,21 @@ const planUpdateFailure = (error) => ({
   error
 });
 
-const addPlanRequest = () => ({
-  type: PlanActionTypes.ADD_PLAN_REQUEST,
+const planCreateRequest = (planValues) => ({
+  type: PlanActionTypes.PLAN_CREATE_REQUEST,
+  planValues,
 });
+
+const planCreateSuccess = (newPlan: IMigPlan) => ({
+  type: PlanActionTypes.PLAN_CREATE_SUCCESS,
+  newPlan,
+});
+
+const planCreateFailure = (error) => ({
+  type: PlanActionTypes.PLAN_CREATE_FAILURE,
+  error,
+});
+
 
 const initStage = (planName: string) => ({
   type: PlanActionTypes.INIT_STAGE,
@@ -297,8 +294,8 @@ const setLockedPlan = (planName) => ({
 
 export const PlanActions = {
   updatePlans,
-  addPlanSuccess,
-  addPlanFailure,
+  planCreateSuccess,
+  planCreateFailure,
   removePlanSuccess,
   updateStageProgress,
   stagingSuccess,
@@ -311,7 +308,6 @@ export const PlanActions = {
   migPlanFetchRequest,
   migPlanFetchSuccess,
   migPlanFetchFailure,
-  pvFetchRequest,
   pvFetchFailure,
   pvFetchSuccess,
   sourceClusterNamespacesFetchSuccess,
@@ -323,7 +319,7 @@ export const PlanActions = {
   planUpdateRequest,
   planUpdateSuccess,
   planUpdateFailure,
-  addPlanRequest,
+  planCreateRequest,
   initStage,
   initMigration,
   planReconcilePolling,

--- a/src/app/plan/duck/operations.ts
+++ b/src/app/plan/duck/operations.ts
@@ -6,7 +6,7 @@ import { CoreClusterResource, CoreClusterResourceKind } from '../../../client/re
 
 import {
   createMigMigration,
-  createInitialMigPlan,
+  createMigPlan,
   updateMigPlanFromValues,
 } from '../../../client/resources/conversions';
 import {
@@ -155,7 +155,7 @@ const addPlan = migPlan => {
       const { migMeta } = getState();
       const client: IClusterClient = ClientFactory.hostCluster(getState());
 
-      const migPlanObj = createInitialMigPlan(
+      const migPlanObj = createMigPlan(
         migPlan.planName,
         migMeta.namespace,
         migPlan.sourceCluster,
@@ -209,10 +209,6 @@ const addPlan = migPlan => {
       dispatch(AlertActions.alertErrorTimeout('Failed to add plan'));
     }
   };
-};
-
-const removePlan = id => {
-  throw new Error('NOT IMPLEMENTED');
 };
 
 const fetchPlans = () => {
@@ -290,7 +286,6 @@ export default {
   pvFetchRequest,
   fetchPlans,
   addPlan,
-  removePlan,
   fetchNamespacesForCluster,
   runStage,
   runMigration,

--- a/src/app/plan/duck/reducers.ts
+++ b/src/app/plan/duck/reducers.ts
@@ -65,10 +65,6 @@ export const migPlanFetchFailure =
   (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.migPlanFetchFailure>) => {
     return { ...state, isError: true, isFetching: false };
   };
-export const pvFetchRequest =
-  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.pvFetchRequest>) => {
-    return { ...state, isPVError: false, isFetchingPVList: true };
-  };
 export const pvFetchFailure =
   (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.pvFetchFailure>) => {
     return { ...state, isPVError: true, isFetchingPVList: false };
@@ -86,8 +82,8 @@ export const stopPlanReconcilePolling =
   (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.stopPlanReconcilePolling>) =>
     ({ ...state, isReconciling: false });
 
-export const addPlanSuccess =
-  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.addPlanSuccess>) => {
+export const planCreateSuccess =
+  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.planCreateSuccess>) => {
     const newPlan = {
       MigPlan: action.newPlan,
       Migrations: [],
@@ -96,20 +92,6 @@ export const addPlanSuccess =
     return {
       ...state,
       migPlanList: [...state.migPlanList, newPlan],
-    };
-  };
-
-export const addPlanFailure =
-  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.addPlanFailure>) => {
-    return {
-      ...state,
-    };
-  };
-
-export const addPlanRequest =
-  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.addPlanRequest>) => {
-    return {
-      ...state,
     };
   };
 
@@ -369,7 +351,6 @@ export const setLockedPlan = (state = INITIAL_STATE, action) => {
 
 const planReducer = (state = INITIAL_STATE, action) => {
   switch (action.type) {
-    case PlanActionTypes.ADD_PLAN_REQUEST: return addPlanRequest(state, action);
     case PlanActionTypes.INIT_STAGE: return initStage(state, action);
     case PlanActionTypes.INIT_MIGRATION: return initMigration(state, action);
     case PlanActionTypes.MIG_PLAN_FETCH_REQUEST: return migPlanFetchRequest(state, action);
@@ -382,9 +363,7 @@ const planReducer = (state = INITIAL_STATE, action) => {
     case PlanActionTypes.PLAN_RECONCILE_POLL: return planReconcilePolling(state, action);
     case PlanActionTypes.PLAN_RECONCILE_POLL_STOP: return stopPlanReconcilePolling(state, action);
     case PlanActionTypes.PV_FETCH_FAILURE: return pvFetchFailure(state, action);
-    case PlanActionTypes.PV_FETCH_REQUEST: return pvFetchRequest(state, action);
-    case PlanActionTypes.ADD_PLAN_SUCCESS: return addPlanSuccess(state, action);
-    case PlanActionTypes.ADD_PLAN_FAILURE: return addPlanFailure(state, action);
+    case PlanActionTypes.PLAN_CREATE_SUCCESS: return planCreateSuccess(state, action);
     case PlanActionTypes.REMOVE_PLAN_SUCCESS: return removePlanSuccess(state, action);
     case PlanActionTypes.STAGING_SUCCESS: return stagingSuccess(state, action);
     case PlanActionTypes.STAGING_FAILURE: return stagingFailure(state, action);

--- a/src/app/plan/duck/reducers.ts
+++ b/src/app/plan/duck/reducers.ts
@@ -29,6 +29,7 @@ export const INITIAL_STATE = {
   isClosing: false,
   isPollingStatus: false,
   isPolling: false,
+  isReconciling: false,
   pvResourceList: [],
   currentPlanStatus: {
     state: CurrentPlanState.Pending,
@@ -76,6 +77,14 @@ export const pvFetchSuccess =
   (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.pvFetchSuccess>) => {
     return { ...state, isPVError: false, isFetchingPVList: false };
   };
+
+export const planReconcilePolling =
+  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.planReconcilePolling>) =>
+    ({ ...state, isReconciling: true });
+
+export const stopPlanReconcilePolling =
+  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.stopPlanReconcilePolling>) =>
+    ({ ...state, isReconciling: false });
 
 export const addPlanSuccess =
   (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.addPlanSuccess>) => {
@@ -370,6 +379,8 @@ const planReducer = (state = INITIAL_STATE, action) => {
     case PlanActionTypes.NAMESPACE_FETCH_SUCCESS: return namespaceFetchSuccess(state, action);
     case PlanActionTypes.NAMESPACE_FETCH_FAILURE: return namespaceFetchFailure(state, action);
     case PlanActionTypes.PV_FETCH_SUCCESS: return pvFetchSuccess(state, action);
+    case PlanActionTypes.PLAN_RECONCILE_POLL: return planReconcilePolling(state, action);
+    case PlanActionTypes.PLAN_RECONCILE_POLL_STOP: return stopPlanReconcilePolling(state, action);
     case PlanActionTypes.PV_FETCH_FAILURE: return pvFetchFailure(state, action);
     case PlanActionTypes.PV_FETCH_REQUEST: return pvFetchRequest(state, action);
     case PlanActionTypes.ADD_PLAN_SUCCESS: return addPlanSuccess(state, action);

--- a/src/app/plan/duck/reducers.ts
+++ b/src/app/plan/duck/reducers.ts
@@ -17,7 +17,6 @@ export interface ICurrentPlanStatus {
 
 export const INITIAL_STATE = {
   isPVError: false,
-  isFetchingPVList: false,
   isFetchingPVResources: false,
   isCheckingPlanStatus: false,
   isError: false,
@@ -61,17 +60,20 @@ export const migPlanFetchSuccess =
     const sortedList = sortPlans(action.migPlanList);
     return { ...state, migPlanList: sortedList, isFetching: false };
   };
+
 export const migPlanFetchFailure =
   (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.migPlanFetchFailure>) => {
     return { ...state, isError: true, isFetching: false };
   };
+
 export const pvFetchFailure =
-  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.pvFetchFailure>) => {
-    return { ...state, isPVError: true, isFetchingPVList: false };
+  (state = INITIAL_STATE, action) => {
+    return { ...state, isPVError: true };
   };
+
 export const pvFetchSuccess =
-  (state = INITIAL_STATE, action: ReturnType<typeof PlanActions.pvFetchSuccess>) => {
-    return { ...state, isPVError: false, isFetchingPVList: false };
+  (state = INITIAL_STATE, action) => {
+    return { ...state, isPVError: false };
   };
 
 export const planReconcilePolling =

--- a/src/app/plan/duck/utils.ts
+++ b/src/app/plan/duck/utils.ts
@@ -4,14 +4,14 @@ const getPlanPVsAndCheckConditions = plan => {
   const statusObj = { success: null, error: null, errorText: null };
   const PvsDiscoveredType = 'PvsDiscovered';
   const NamespaceLimitErrorType = 'NamespaceLimitExceeded';
-  if (plan.MigPlan.status && plan.MigPlan.status.conditions) {
-    const maxNamespaceError = !!plan.MigPlan.status.conditions.some(c => c.type === NamespaceLimitErrorType);
+  if (plan.status && plan.status.conditions) {
+    const maxNamespaceError = !!plan.status.conditions.some(c => c.type === NamespaceLimitErrorType);
     if (maxNamespaceError) {
       statusObj.error = maxNamespaceError;
       statusObj.errorText = 'Namespace limit Exceeded.';
     }
     else {
-      const pvsDiscovered = !!plan.MigPlan.status.conditions.some(c => c.type === PvsDiscoveredType);
+      const pvsDiscovered = !!plan.status.conditions.some(c => c.type === PvsDiscoveredType);
 
       if (pvsDiscovered) {
         statusObj.success = pvsDiscovered;

--- a/src/app/plan/duck/utils.ts
+++ b/src/app/plan/duck/utils.ts
@@ -5,23 +5,21 @@ const getPlanPVsAndCheckConditions = plan => {
   const PvsDiscoveredType = 'PvsDiscovered';
   const NamespaceLimitErrorType = 'NamespaceLimitExceeded';
   if (plan.status && plan.status.conditions) {
-    const maxNamespaceError = !!plan.status.conditions.some(c => c.type === NamespaceLimitErrorType);
+    const maxNamespaceError = plan.status.conditions.find(c => c.type === NamespaceLimitErrorType);
     if (maxNamespaceError) {
-      statusObj.error = maxNamespaceError;
-      statusObj.errorText = 'Namespace limit Exceeded.';
+      statusObj.error = maxNamespaceError.message;
+      return statusObj;
     }
-    else {
-      const pvsDiscovered = !!plan.status.conditions.some(c => c.type === PvsDiscoveredType);
 
-      if (pvsDiscovered) {
-        statusObj.success = pvsDiscovered;
-      }
-
+    const pvsDiscovered = !!plan.status.conditions.some(c => c.type === PvsDiscoveredType);
+    if (pvsDiscovered) {
+      statusObj.success = pvsDiscovered;
     }
   }
 
   return statusObj;
 };
+
 const getPlanStatus = plan => {
   const statusObj = { success: null, error: null };
   if (!plan.MigPlan.status || !plan.MigPlan.status.conditions) { return statusObj; }

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -190,11 +190,11 @@ export function updatePlanSourceCluster(migPlan: ReturnType<typeof createMigPlan
 }
 
 export function updatePlanDestinationCluster(migPlan: ReturnType<typeof createMigPlan>, planValues: any): boolean {
-  if (!planValues.destinationCluster || planValues.destinationCluster === migPlan.spec.destMigClusterRef.name) {
+  if (!planValues.targetCluster || planValues.targetCluster === migPlan.spec.destMigClusterRef.name) {
     return false;
   }
 
-  migPlan.spec.destMigClusterRef.name = planValues.destinationCluster;
+  migPlan.spec.destMigClusterRef.name = planValues.targetCluster;
 
   return true;
 }

--- a/src/sagas.ts
+++ b/src/sagas.ts
@@ -13,6 +13,7 @@ export default function* rootSaga() {
     commonSagas.watchStoragePolling(),
     commonSagas.watchAlerts(),
     planSagas.watchPVPolling(),
+    planSagas.watchPlanReconcilePolling(),
     planSagas.watchPlanUpdate(),
     planSagas.watchPlanCloseAndDelete(),
     planSagas.watchPlanClose(),

--- a/src/sagas.ts
+++ b/src/sagas.ts
@@ -14,6 +14,7 @@ export default function* rootSaga() {
     commonSagas.watchAlerts(),
     planSagas.watchPVPolling(),
     planSagas.watchPlanReconcilePolling(),
+    planSagas.watchPlanCreate(),
     planSagas.watchPlanUpdate(),
     planSagas.watchPlanCloseAndDelete(),
     planSagas.watchPlanClose(),


### PR DESCRIPTION
Plan is to leverage #590 
Fixes "Bug 1758336 - [MIG UI] Unable to edit namespace selection." in combination with #610 
Closes #614
Changes:
- Undo functionality, reconcile watch.
- Resource version polling. Idea is to set it as a preceding step before viewing/operating on any plan's state values.
- Put instead of patch on migPlan creation.
- Improved performance
- Added resourceVersion driven checks.
- Added deduplication on plan update.
- Refactored logic of migration plan creation/editation + closure.