### PR TITLE
Fix results page status displaying wrong information

### DIFF
--- a/src/app/plan/components/Wizard/ResultsStep.tsx
+++ b/src/app/plan/components/Wizard/ResultsStep.tsx
@@ -36,15 +36,6 @@ const ResultsStep: React.FunctionComponent<IProps> = props => {
   };
 
   function HeaderIcon({ state }) {
-    const StyledIcon = styled(RedoIcon)`
-      height: 1.3em;
-      width: 1.3em;
-    `;
-    const StyledLoaderWrapper = styled.span`
-      display: inline-block;
-      margin-right: 0.75rem;
-    `;
-
     switch (state) {
       case CurrentPlanState.Pending:
         return <Spinner size="xl" />;

--- a/src/app/plan/components/Wizard/WizardComponent.tsx
+++ b/src/app/plan/components/Wizard/WizardComponent.tsx
@@ -8,6 +8,7 @@ import ResultsStep from './ResultsStep';
 import { PollingContext } from '../../../home/duck/context';
 import { FormikProps } from 'formik';
 import { IOtherProps, IFormValues } from './WizardContainer';
+import { ICurrentPlanStatus, CurrentPlanState } from '../../duck/reducers';
 
 const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
   const [stepIdReached, setStepIdReached] = useState(1);
@@ -44,7 +45,8 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     pvResourceList,
     addPlan,
     resetCurrentPlan,
-    onHandleWizardModalClose
+    onHandleWizardModalClose,
+    updateCurrentPlanStatus
   } = props;
 
   enum stepId {
@@ -176,7 +178,8 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
     isFetchingNamespaceList,
     pvResourceList,
     errors,
-    touched
+    touched,
+    currentPlanStatus
   ]);
 
 
@@ -200,9 +203,8 @@ const WizardComponent = (props: IOtherProps & FormikProps<IFormValues>) => {
       }
     }
     if (curr.id === stepId.Results) {
-      //update plan & start status polling on results page
+      updateCurrentPlanStatus({ state: CurrentPlanState.Pending });
       planUpdateRequest(props.values);
-      startPlanStatusPolling(props.values.planName);
     }
   };
   const handleClose = () => {

--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -37,6 +37,7 @@ export interface IOtherProps {
   sourceClusterNamespaces: any[];
   pvResourceList: any[];
   onHandleWizardModalClose: () => void;
+  updateCurrentPlanStatus: any;
 }
 
 const WizardContainer = withFormik<IOtherProps, IFormValues>({
@@ -125,6 +126,7 @@ const mapDispatchToProps = dispatch => {
     startPlanStatusPolling: (planName) => dispatch(PlanActions.startPlanStatusPolling(planName)),
     planUpdateRequest: (values) => dispatch(PlanActions.planUpdateRequest(values)),
     resetCurrentPlan: () => dispatch(PlanActions.resetCurrentPlan()),
+    updateCurrentPlanStatus: (status) => dispatch(PlanActions.updateCurrentPlanStatus(status)),
   };
 };
 

--- a/src/app/plan/duck/sagas.ts
+++ b/src/app/plan/duck/sagas.ts
@@ -105,13 +105,17 @@ function* putPlanSaga(planValues) {
   try {
     const getPlanRes = yield call(getPlanSaga, planValues.planName);
     const updatedMigPlan = updateMigPlanFromValues(getPlanRes.data, planValues);
-    const putPlanResponse = yield client.put(
+    yield client.put(
       new MigResource(MigResourceKind.MigPlan, migMeta.namespace),
       getPlanRes.data.metadata.name,
       updatedMigPlan
     );
+    yield delay(5000);
     yield put(PlanActions.planUpdateSuccess());
-    yield put(PlanActions.updatePlanList(putPlanResponse.data));
+    const getPlanResponse = yield call(getPlanSaga, planValues.planName);
+    const updatedPlan = getPlanResponse.data;
+    yield put(PlanActions.updatePlanList(updatedPlan));
+    yield put(PlanActions.startPlanStatusPolling(planValues.planName));
   } catch (err) {
     yield put(PlanActions.planUpdateFailure(err));
     throw err;


### PR DESCRIPTION
Closes #614 

Before, we were using the put request response as the updated plan value. This value does not include the updated status/conditions from the controller as it takes a few seconds for the controller to add this. This PR moves the status poll request function to inside the put request saga which allows the PUT & GET requests to resolve before status polling begins. 