### PR TITLE
Only update redux tree if the clusters have actually been updated

### DIFF
--- a/src/app/plan/duck/reducers.ts
+++ b/src/app/plan/duck/reducers.ts
@@ -177,18 +177,31 @@ export const updatePlanMigrations =
 
 export const updatePlans =
   (state = INITIAL_STATE, action) => {
-    const updatedPlanList = action.updatedPlans.map(p => {
-      //filter migrations
-      p.Migrations = sortMigrations(p.Migrations);
-      return p;
+    const updatedPlanList = action.updatedPlans.map(plan => {
+      plan.Migrations = sortMigrations(plan.Migrations);
+      const { metadata } = plan.MigPlan;
+      if (metadata.annotations || metadata.generation || metadata.resourceVersion) {
+        delete metadata.annotations;
+        delete metadata.generation;
+        delete metadata.resourceVersion;
+      }
+      return plan;
     });
 
     const sortedList = sortPlans(updatedPlanList);
 
-    return {
-      ...state,
-      migPlanList: sortedList,
-    };
+    if (JSON.stringify(sortedList) === JSON.stringify(state.migPlanList)) {
+      return {
+        ...state
+      };
+    } else if
+      (JSON.stringify(sortedList) !== JSON.stringify(state.migPlanList)) {
+
+      return {
+        ...state,
+        migPlanList: sortedList,
+      };
+    }
   };
 
 export const initStage =

--- a/src/app/storage/duck/reducers.ts
+++ b/src/app/storage/duck/reducers.ts
@@ -1,6 +1,7 @@
 import { fetchingAddEditStatus } from '../../common/add_edit_state';
 import { StorageActionTypes } from './actions';
 import { defaultAddEditStatus } from '../../common/add_edit_state';
+import moment from 'moment';
 
 export const INITIAL_STATE = {
   isPolling: false,
@@ -11,6 +12,13 @@ export const INITIAL_STATE = {
   searchTerm: '',
   addEditStatus: defaultAddEditStatus(),
 };
+
+const sortStorageList = storageList =>
+  storageList.sort((left, right) => {
+    return moment
+      .utc(right.MigStorage.metadata.creationTimestamp)
+      .diff(moment.utc(left.MigStorage.metadata.creationTimestamp));
+  });
 
 export const migStorageFetchRequest = (state = INITIAL_STATE, action) => {
   return { ...state, isFetching: true };
@@ -80,10 +88,34 @@ export const updateStorageSuccess = (state = INITIAL_STATE, action) => {
 };
 
 export const updateStorages = (state = INITIAL_STATE, action) => {
-  return {
-    ...state,
-    migStorageList: action.updatedStorages,
-  };
+  const updatedStorageList = action.updatedStorages.map(storage => {
+    const { metadata } = storage.MigStorage;
+    if (metadata.annotations || metadata.generation || metadata.resourceVersion) {
+      delete metadata.annotations;
+      delete metadata.generation;
+      delete metadata.resourceVersion;
+    }
+    if (storage.MigStorage.status) {
+      for (let i = 0; storage.MigStorage.status.conditions.length > i; i++) {
+        delete storage.MigStorage.status.conditions[i].lastTransitionTime;
+      }
+    }
+    return storage;
+  });
+
+  const sortedList = sortStorageList(updatedStorageList);
+
+  if (JSON.stringify(sortedList) === JSON.stringify(state.migStorageList)) {
+    return {
+      ...state
+    };
+  } else if
+    (JSON.stringify(sortedList) !== JSON.stringify(state.migStorageList)) {
+    return {
+      ...state,
+      migStorageList: sortedList,
+    };
+  }
 };
 
 export const setStorageAddEditStatus = (state = INITIAL_STATE, action) => {


### PR DESCRIPTION
Improves performance by limiting rerenders from background polling