### PR TITLE
Only "Velero_Backups" resources group is allowed to execute an Azure snapshot migration

### DIFF
--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -177,7 +177,7 @@ export function createMigStorage(
           volumeSnapshotConfig: {
             //azure specific config
             azureApiTimeout: '30s',
-            azureResourceGroup: 'Velero_Backups',
+            azureResourceGroup,
             credsSecretRef: {
               name: tokenSecret.metadata.name,
               namespace: tokenSecret.metadata.namespace,


### PR DESCRIPTION
Fixing hardcoded value for azure resoruce group