### PR TITLE
Initial implementation for discovery client

### DIFF
--- a/config/config.dev.json.example
+++ b/config/config.dev.json.example
@@ -6,5 +6,6 @@
   "redirectUri": "http://localhost:9000/login/callback",
   "namespace": "openshift-migration",
   "configNamespace": "openshift-config",
-  "oauthClientSecret": "bWlncmF0aW9ucy5vcGVuc2hpZnQuaW8K"
+  "oauthClientSecret": "bWlncmF0aW9ucy5vcGVuc2hpZnQuaW8K",
+  "discoveryApi": "http://discovery-api.supercluster.example.com"
 }

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -47,6 +47,7 @@ migMeta.oauth = {
 };
 migMeta.namespace = localConfig.namespace;
 migMeta.configNamespace = localConfig.configNamespace;
+migMeta.discoveryApi = localConfig.discoveryApi;
 
 htmlWebpackPluginOpt.migMeta = Buffer.from(JSON.stringify(migMeta)).toString('base64');
 const PORT = process.env.PORT || localConfig.devServerPort;

--- a/deploy/roles/mig-ui/defaults/main.yml
+++ b/deploy/roles/mig-ui/defaults/main.yml
@@ -4,7 +4,7 @@ mig_ui_name: mig-ui
 mig_ui_namespace: mig
 mig_ui_image: quay.io/ocpmigrate/mig-ui:latest
 mig_ui_image_pull_policy: Always
-mig_ui_migmeta_configmap_name : mig-ui-config
+mig_ui_migmeta_configmap_name: mig-ui-config
 mig_ui_secrets_namespace: mig
 mig_ui_oauth_user_scope: "user:full"
 mig_ui_oauth_client_id: "{{ mig_ui_name }}"

--- a/src/client/client_factory.ts
+++ b/src/client/client_factory.ts
@@ -58,8 +58,7 @@ export const ClientFactory = {
       throw new ClientFactoryMissingDiscoveryApi();
     }
 
-    const discoveryApi = state.migMeta.discoveryApi;
-    const discoveryClient = new DiscoveryClient(discoveryApi);
+    const discoveryClient = new DiscoveryClient(state.migMeta.discoveryApi, state.migMeta.namespace);
     return discoveryClient;
   }
 };

--- a/src/client/discoveryClient.ts
+++ b/src/client/discoveryClient.ts
@@ -1,17 +1,24 @@
 import axios, { AxiosPromise, AxiosInstance, ResponseType } from 'axios';
-import { DiscoveryResource } from './resources/common';
+import { ClusterDiscoveryResource } from './resources/common';
 
 export interface IDiscoveryClient {
-  get(resource: DiscoveryResource, params?: object): Promise<any>;
+  get(resource: ClusterDiscoveryResource, params?: object): Promise<any>;
 }
 
 export class DiscoveryClient {
   private token: string;
   public discoveryApi: string;
+  private _discoveryNamespace: string;
   private requester: AxiosInstance;
 
-  constructor(discoveryApi: string, token?: string, customResponseType: ResponseType = 'json') {
+  constructor(
+    discoveryApi: string,
+    discoveryNamespace: string,
+    token?: string,
+    customResponseType: ResponseType = 'json') {
+
     this.discoveryApi = discoveryApi;
+    this._discoveryNamespace = discoveryNamespace;
     this.token = token;
     const headers = {
       'Content-Type': 'application/json',
@@ -20,13 +27,13 @@ export class DiscoveryClient {
       headers['Authorization'] = `Bearer ${this.token}`;
     }
     this.requester = axios.create({
-      baseURL: this.discoveryApi,
+      baseURL: [this.discoveryApi, 'namespaces', this._discoveryNamespace].join('/'),
       headers,
       responseType: customResponseType,
     });
   }
 
-  public get = (resource: DiscoveryResource, params?: object): AxiosPromise<any> => {
+  public get = (resource: ClusterDiscoveryResource, params?: object): AxiosPromise<any> => {
     return new Promise((resolve, reject) => {
       this.requester.get(resource.for(), { ...resource.parametrizedPath(params) })
         .then(res => resolve(res))

--- a/src/client/discoveryClient.ts
+++ b/src/client/discoveryClient.ts
@@ -14,7 +14,7 @@ export class DiscoveryClient {
   constructor(
     discoveryApi: string,
     discoveryNamespace: string,
-    token?: string,
+    token: string,
     customResponseType: ResponseType = 'json') {
 
     this.discoveryApi = discoveryApi;

--- a/src/client/discoveryClient.ts
+++ b/src/client/discoveryClient.ts
@@ -1,0 +1,42 @@
+import axios, { AxiosPromise, AxiosInstance, ResponseType } from 'axios';
+import { DiscoveryResource } from './resources/common';
+
+export interface IDiscoveryClient {
+  get(resource: DiscoveryResource, params?: object): Promise<any>;
+}
+
+export class DiscoveryClient {
+  private token: string;
+  public discoveryApi: string;
+  private requester: AxiosInstance;
+
+  constructor(discoveryApi: string, customResponseType: ResponseType = 'json', token?: string) {
+    this.discoveryApi = discoveryApi;
+    this.token = token;
+    const headers = {
+      'Content-Type': 'application/json',
+    };
+    if (token) {
+      headers['Authorization'] = `Bearer ${this.token}`;
+    }
+    this.requester = axios.create({
+      baseURL: this.discoveryApi,
+      headers,
+      responseType: customResponseType,
+    });
+  }
+
+  public get = (resource: DiscoveryResource, params?: object): AxiosPromise<any> => {
+    params = {
+      ...resource.for(),
+      ...resource.parametrizedPath(params)
+    };
+    return new Promise((resolve, reject) => {
+      this.requester.get(resource.type, { params })
+        .then(res => resolve(res))
+        .catch(err => {
+          reject(err);
+        });
+    });
+  }
+}

--- a/src/client/discoveryClient.ts
+++ b/src/client/discoveryClient.ts
@@ -10,7 +10,7 @@ export class DiscoveryClient {
   public discoveryApi: string;
   private requester: AxiosInstance;
 
-  constructor(discoveryApi: string, customResponseType: ResponseType = 'json', token?: string) {
+  constructor(discoveryApi: string, token?: string, customResponseType: ResponseType = 'json') {
     this.discoveryApi = discoveryApi;
     this.token = token;
     const headers = {
@@ -27,12 +27,8 @@ export class DiscoveryClient {
   }
 
   public get = (resource: DiscoveryResource, params?: object): AxiosPromise<any> => {
-    params = {
-      ...resource.for(),
-      ...resource.parametrizedPath(params)
-    };
     return new Promise((resolve, reject) => {
-      this.requester.get(resource.type, { params })
+      this.requester.get(resource.for(), { ...resource.parametrizedPath(params) })
         .then(res => resolve(res))
         .catch(err => {
           reject(err);

--- a/src/client/resources/common.ts
+++ b/src/client/resources/common.ts
@@ -71,7 +71,9 @@ export abstract class DiscoveryResource {
   }
 
   public parametrizedPath(params = {}) {
-    params['wait'] = this.discoveryPath().wait.toString();
+    if (this.discoveryPath().wait !== -1) {
+      params['wait'] = this.discoveryPath().wait.toString();
+    }
     if (this.discoveryPath().offset !== -1) {
       params['offset'] = this.discoveryPath().offset.toString();
     }

--- a/src/client/resources/common.ts
+++ b/src/client/resources/common.ts
@@ -57,29 +57,27 @@ function namedPath(listPath, name) {
   return [listPath, name].join('/');
 }
 
-export abstract class DiscoveryResource {
+export abstract class ClusterDiscoveryResource {
 
   private _type: string;
-  private _namespace: string;
+  private _cluster: string;
+
   public abstract discoveryParameters(): IDiscoveryParametrs;
   public abstract for(): string;
 
-  constructor(namespace: string, type: string) {
-    if (!type) {
-      throw new Error('DiscoveryResource must have a type, it was undefined');
+  constructor(cluster: string, type: string) {
+    if (!cluster) {
+      throw new Error('ClusterDiscoveryResource must have a cluster, it was undefined');
     }
-    if (!namespace) {
-      throw new Error('DiscoveryResource must have a namespace, it was undefined');
-    }
+    this._cluster = cluster;
     this._type = type;
-    this._namespace = namespace;
-  }
-
-  public discoveryNamespace() {
-    return ['namespaces', this._namespace].join('/');
   }
 
   public discoveryType() { return this._type + '/'; }
+
+  public discoveryCluster() {
+    return ['clusters', this._cluster].join('/');
+  }
 
   public parametrizedPath(params = {}) {
     if (this.discoveryParameters().wait !== -1) {
@@ -95,20 +93,4 @@ export abstract class DiscoveryResource {
     return params;
   }
 
-}
-
-export abstract class ClusterDiscoveryResource extends DiscoveryResource {
-  private _cluster: string;
-
-  constructor(namespace: string, cluster: string, type: string) {
-    if (!cluster) {
-      throw new Error('ClusterDiscoveryResource must have a cluster, it was undefined');
-    }
-    super(namespace, type);
-    this._cluster = cluster;
-  }
-
-  public discoveryCluster() {
-    return ['clusters', this._cluster].join('/');
-  }
 }

--- a/src/client/resources/common.ts
+++ b/src/client/resources/common.ts
@@ -11,7 +11,7 @@ export interface IGroupVersionKindPlural {
   kindPlural: string;
 }
 
-export interface IDiscoveryPath {
+export interface IDiscoveryParametrs {
   wait: number;
   offset?: number;
   limit?: number;
@@ -59,29 +59,56 @@ function namedPath(listPath, name) {
 
 export abstract class DiscoveryResource {
 
-  public type: string;
-  public abstract discoveryPath(): IDiscoveryPath;
-  public abstract for(): object;
+  private _type: string;
+  private _namespace: string;
+  public abstract discoveryParameters(): IDiscoveryParametrs;
+  public abstract for(): string;
 
-  constructor(type: string) {
+  constructor(namespace: string, type: string) {
     if (!type) {
       throw new Error('DiscoveryResource must have a type, it was undefined');
     }
-    this.type = type + '/';
+    if (!namespace) {
+      throw new Error('DiscoveryResource must have a namespace, it was undefined');
+    }
+    this._type = type;
+    this._namespace = namespace;
   }
 
+  public discoveryNamespace() {
+    return ['namespaces', this._namespace].join('/');
+  }
+
+  public discoveryType() { return this._type + '/'; }
+
   public parametrizedPath(params = {}) {
-    if (this.discoveryPath().wait !== -1) {
-      params['wait'] = this.discoveryPath().wait.toString();
+    if (this.discoveryParameters().wait !== -1) {
+      params['wait'] = this.discoveryParameters().wait.toString();
     }
-    if (this.discoveryPath().offset !== -1) {
-      params['offset'] = this.discoveryPath().offset.toString();
+    if (this.discoveryParameters().offset !== -1) {
+      params['offset'] = this.discoveryParameters().offset.toString();
     }
-    if (this.discoveryPath().limit !== -1) {
-      params['limit'] = this.discoveryPath().limit.toString();
+    if (this.discoveryParameters().limit !== -1) {
+      params['limit'] = this.discoveryParameters().limit.toString();
     }
 
     return params;
   }
 
+}
+
+export abstract class ClusterDiscoveryResource extends DiscoveryResource {
+  private _cluster: string;
+
+  constructor(namespace: string, cluster: string, type: string) {
+    if (!cluster) {
+      throw new Error('ClusterDiscoveryResource must have a cluster, it was undefined');
+    }
+    super(namespace, type);
+    this._cluster = cluster;
+  }
+
+  public discoveryCluster() {
+    return ['clusters', this._cluster].join('/');
+  }
 }

--- a/src/client/resources/common.ts
+++ b/src/client/resources/common.ts
@@ -11,6 +11,12 @@ export interface IGroupVersionKindPlural {
   kindPlural: string;
 }
 
+export interface IDiscoveryPath {
+  wait: number;
+  offset?: number;
+  limit?: number;
+}
+
 export abstract class NamespacedResource {
   public abstract gvk(): IGroupVersionKindPlural;
   public namespace: string;
@@ -49,4 +55,31 @@ export abstract class ClusterResource {
 
 function namedPath(listPath, name) {
   return [listPath, name].join('/');
+}
+
+export abstract class DiscoveryResource {
+
+  public type: string;
+  public abstract discoveryPath(): IDiscoveryPath;
+  public abstract for(): object;
+
+  constructor(type: string) {
+    if (!type) {
+      throw new Error('DiscoveryResource must have a type, it was undefined');
+    }
+    this.type = type + '/';
+  }
+
+  public parametrizedPath(params = {}) {
+    params['wait'] = this.discoveryPath().wait.toString();
+    if (this.discoveryPath().offset !== -1) {
+      params['offset'] = this.discoveryPath().offset.toString();
+    }
+    if (this.discoveryPath().limit !== -1) {
+      params['limit'] = this.discoveryPath().limit.toString();
+    }
+
+    return params;
+  }
+
 }

--- a/src/client/resources/discovery.ts
+++ b/src/client/resources/discovery.ts
@@ -1,25 +1,27 @@
-import { DiscoveryResource, IDiscoveryPath } from './common';
+import { ClusterDiscoveryResource, IDiscoveryParametrs } from './common';
 
-export class NamespaceDiscovery extends DiscoveryResource {
-  private _discoveryPath: IDiscoveryPath;
-  private _cluster: string;
+export class NamespaceDiscovery extends ClusterDiscoveryResource {
+  private _discoveryParameters: IDiscoveryParametrs;
 
   constructor(namespace: string, cluster: string, { wait = -1, offset = -1, limit = -1 } = {}) {
-    super('namespaces');
+    super(namespace, cluster, 'namespaces');
 
-    this._cluster = [namespace, cluster].join('/');
-    this._discoveryPath = {
+    this._discoveryParameters = {
       'wait': wait,
       'offset': offset,
       'limit': limit,
     };
   }
 
-  public discoveryPath(): IDiscoveryPath {
-    return this._discoveryPath;
+  public discoveryParameters(): IDiscoveryParametrs {
+    return this._discoveryParameters;
   }
 
   public for() {
-    return { 'cluster': this._cluster };
+    return [
+      this.discoveryNamespace(),
+      this.discoveryCluster(),
+      this.discoveryType(),
+    ].join('/');
   }
 }

--- a/src/client/resources/discovery.ts
+++ b/src/client/resources/discovery.ts
@@ -4,7 +4,7 @@ export class NamespaceDiscovery extends DiscoveryResource {
   private _discoveryPath: IDiscoveryPath;
   private _cluster: string;
 
-  constructor(namespace: string, cluster: string, { wait = 5, offset = -1, limit = -1 } = {}) {
+  constructor(namespace: string, cluster: string, { wait = -1, offset = -1, limit = -1 } = {}) {
     super('namespaces');
 
     this._cluster = [namespace, cluster].join('/');

--- a/src/client/resources/discovery.ts
+++ b/src/client/resources/discovery.ts
@@ -3,8 +3,8 @@ import { ClusterDiscoveryResource, IDiscoveryParametrs } from './common';
 export class NamespaceDiscovery extends ClusterDiscoveryResource {
   private _discoveryParameters: IDiscoveryParametrs;
 
-  constructor(namespace: string, cluster: string, { wait = -1, offset = -1, limit = -1 } = {}) {
-    super(namespace, cluster, 'namespaces');
+  constructor(cluster: string, { wait = -1, offset = -1, limit = -1 } = {}) {
+    super(cluster, 'namespaces');
 
     this._discoveryParameters = {
       'wait': wait,
@@ -19,7 +19,6 @@ export class NamespaceDiscovery extends ClusterDiscoveryResource {
 
   public for() {
     return [
-      this.discoveryNamespace(),
       this.discoveryCluster(),
       this.discoveryType(),
     ].join('/');

--- a/src/client/resources/discovery.ts
+++ b/src/client/resources/discovery.ts
@@ -1,0 +1,25 @@
+import { DiscoveryResource, IDiscoveryPath } from './common';
+
+export class NamespaceDiscovery extends DiscoveryResource {
+  private _discoveryPath: IDiscoveryPath;
+  private _cluster: string;
+
+  constructor(namespace: string, cluster: string, { wait = 5, offset = -1, limit = -1 } = {}) {
+    super('namespaces');
+
+    this._cluster = [namespace, cluster].join('/');
+    this._discoveryPath = {
+      'wait': wait,
+      'offset': offset,
+      'limit': limit,
+    };
+  }
+
+  public discoveryPath(): IDiscoveryPath {
+    return this._discoveryPath;
+  }
+
+  public for() {
+    return { 'cluster': this._cluster };
+  }
+}


### PR DESCRIPTION
```js
const discoveryClient: IDiscoveryClient = ClientFactory.discovery(state);
const namespaces = new NamespaceDiscovery(state.migMeta.namespace, clusterName);
const res = await discoveryClient.get(namespaces);
```

This PR introduces client for Discovery resources. The `config.dev.json` have a new change, and will need another field for `discoveryApi`, which will be used for namespace discovery:
```json
  "discoveryApi": "http://discovery-api.supercluster.example.com",
```