### PR TITLE
Allow disabling SSL verification for S3-compatible storage

### DIFF
--- a/cypress/integration/storage.spec.js
+++ b/cypress/integration/storage.spec.js
@@ -21,6 +21,7 @@ describe('Storage functionality test', () => {
             cy.get('#bucketRegion').type(bucketRegion);
             cy.get('#accessKey').type(accessKey);
             cy.get('#secret').type(secret);
+            cy.get('#require-ssl-input').check();
             cy.get('#check-connection-btn').click();
             cy.get('#submit-cluster-btn').click();
           });
@@ -38,6 +39,7 @@ describe('Storage functionality test', () => {
             cy.get('#bucketRegion').type(bucketRegion);
             cy.get('#accessKey').type(accessKey);
             cy.get('#secret').type(secret);
+            cy.get('#require-ssl-input').check();
             cy.get('#check-connection-btn').should('be.disabled');
             cy.get('#submit-cluster-btn').should('be.disabled');
           });

--- a/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/AddEditStorageForm.tsx
@@ -36,6 +36,7 @@ const AddEditStorageForm = (props: IOtherProps) => {
   let azureStorageAccount;
   let azureBlob;
   let gcpBlob;
+  let requireSSL;
   if (storage) {
     name = storage.MigStorage.metadata.name;
     provider = storage.MigStorage.spec.backupStorageProvider;
@@ -45,6 +46,7 @@ const AddEditStorageForm = (props: IOtherProps) => {
     gcpBucket = storage.MigStorage.spec.backupStorageConfig.gcpBucket;
     azureResourceGroup = storage.MigStorage.spec.backupStorageConfig.azureResourceGroup;
     azureStorageAccount = storage.MigStorage.spec.backupStorageConfig.azureStorageAccount;
+    requireSSL = !storage.MigStorage.spec.backupStorageConfig.insecure;
     accessKey =
       typeof storage.Secret === 'undefined'
         ? null
@@ -119,7 +121,7 @@ const AddEditStorageForm = (props: IOtherProps) => {
       </Box>
       {(selectedProvider && selectedProvider.value === 'aws') &&
         <AWSForm provider={selectedProvider.value}
-          initialStorageValues={{ name, awsBucketName, awsBucketRegion, s3Url, accessKey, secret }}
+          initialStorageValues={{ name, awsBucketName, awsBucketRegion, s3Url, accessKey, secret, requireSSL }}
           {...props} />
       }
       {(selectedProvider && selectedProvider.value === 'azure') &&

--- a/src/app/storage/components/AddEditStorageModal/ProviderForms/AWSForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/ProviderForms/AWSForm.tsx
@@ -39,6 +39,7 @@ const valuesHaveUpdate = (values, currentStorage) => {
     const existingAWSBucketName = currentStorage.MigStorage.spec.backupStorageConfig.awsBucketName;
     const existingAWSBucketRegion = currentStorage.MigStorage.spec.backupStorageConfig.awsRegion || '';
     const existingBucketUrl = currentStorage.MigStorage.spec.backupStorageConfig.awsS3Url || '';
+    const existingRequireSSL = !currentStorage.MigStorage.spec.backupStorageConfig.insecure;
     let existingAccessKeyId;
     if (currentStorage.Secret.data['aws-access-key-id']) {
         existingAccessKeyId = atob(currentStorage.Secret.data['aws-access-key-id']);
@@ -56,7 +57,8 @@ const valuesHaveUpdate = (values, currentStorage) => {
         values.bucketRegion !== existingAWSBucketRegion ||
         values.s3Url !== existingBucketUrl ||
         values.accessKey !== existingAccessKeyId ||
-        values.secret !== existingSecretAccessKey;
+        values.secret !== existingSecretAccessKey ||
+        values.requireSSL !== existingRequireSSL;
 
     return valuesUpdatedObject;
 };
@@ -69,6 +71,7 @@ interface IFormValues {
     secret: string;
     s3Url: string;
     bslProvider: string;
+    requireSSL: boolean;
 }
 interface IOtherProps {
     onAddEditSubmit: any;
@@ -105,6 +108,7 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
     const secretKey = 'secret';
     const vslConfigKey = 'vslConfig';
     const vslBlobKey = 'vslBlob';
+    const requireSSLKey = 'requireSSL';
 
     const [isAccessKeyHidden, setIsAccessKeyHidden] = useState(true);
     const [isSharedCred, setIsSharedCred] = useState(true);
@@ -217,6 +221,17 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     <FormErrorDiv id="feedback-secret-key">{errors.secret}</FormErrorDiv>
                 )}
             </FormGroup>
+            <FormGroup fieldId={requireSSLKey}>
+              <Checkbox
+                onChange={formikHandleChange}
+                onInput={formikSetFieldTouched(requireSSLKey)}
+                onBlur={handleBlur}
+                isChecked={values.requireSSL}
+                name={requireSSLKey}
+                label="Require SSL verification"
+                id="require-ssl-input"
+              />
+            </FormGroup>
             <Flex flexDirection="column">
                 <Box m="0 0 1em 0 ">
                     <Button
@@ -289,6 +304,7 @@ const AWSForm: any = withFormik({
             secret: '',
             s3Url: '',
             bslProvider: provider,
+            requireSSL: true,
         };
 
         if (initialStorageValues) {
@@ -298,6 +314,7 @@ const AWSForm: any = withFormik({
             values.accessKey = initialStorageValues.accessKey || '';
             values.secret = initialStorageValues.secret || '';
             values.s3Url = initialStorageValues.s3Url || '';
+            values.requireSSL = initialStorageValues.requireSSL;
             // values.bslProvider = provider;
         }
 

--- a/src/app/storage/duck/sagas.ts
+++ b/src/app/storage/duck/sagas.ts
@@ -49,6 +49,7 @@ function* addStorageRequest(action) {
     storageValues.bslProvider,
     migMeta.namespace,
     storageSecret,
+    storageValues.requireSSL,
     storageValues.awsBucketName,
     storageValues.awsBucketRegion,
     storageValues.s3Url,
@@ -197,6 +198,9 @@ function* updateStorageRequest(action) {
     currentStorage.MigStorage.spec.backupStorageConfig.awsS3Url;
 
   const s3UrlUpdated = storageValues.s3Url !== currentS3Url;
+
+  const currentRequireSSL = !currentStorage.MigStorage.spec.backupStorageConfig.insecure;
+  const requireSSLUpdated = storageValues.requireSSL !== currentRequireSSL;
   //
   //GCP
   const currentGCPBucketName =
@@ -221,9 +225,10 @@ function* updateStorageRequest(action) {
     bucketNameUpdated ||
     regionUpdated ||
     s3UrlUpdated ||
+    requireSSLUpdated ||
     //GCP
     gcpBucketNameUpdated ||
-    //Azure 
+    //Azure
     azureResourceGroupUpdated ||
     azureStorageAccountUpdated;
 
@@ -277,6 +282,7 @@ function* updateStorageRequest(action) {
       storageValues.gcpBucket,
       storageValues.azureResourceGroup,
       storageValues.azureStorageAccount,
+      storageValues.requireSSL,
     );
     const migStorageResource = new MigResource(
       MigResourceKind.MigStorage, migMeta.namespace);

--- a/src/client/resources/conversions.ts
+++ b/src/client/resources/conversions.ts
@@ -89,6 +89,7 @@ export function createMigStorage(
   bslProvider: string,
   namespace: string,
   tokenSecret: any,
+  requireSSL: boolean,
   awsBucketName?: string,
   awsBucketRegion?: string,
   s3Url?: string,
@@ -116,6 +117,7 @@ export function createMigStorage(
               name: tokenSecret.metadata.name,
               namespace: tokenSecret.metadata.namespace,
             },
+            insecure: !requireSSL,
           },
           volumeSnapshotConfig: {
             awsRegion: awsBucketRegion,
@@ -197,7 +199,8 @@ export function updateMigStorage(
   s3Url: string,
   gcpBucket: string,
   azureResourceGroup: string,
-  azureStorageAccount: string
+  azureStorageAccount: string,
+  requireSSL: boolean,
 ) {
   switch (bslProvider) {
     case 'aws':
@@ -207,6 +210,7 @@ export function updateMigStorage(
             awsBucketName: bucketName,
             awsRegion: bucketRegion,
             awsS3Url: s3Url,
+            insecure: !requireSSL,
           },
           volumeSnapshotConfig: {
             awsRegion: bucketRegion,


### PR DESCRIPTION
Adds a checkbox to turn off SSL verification for s3-compatible storage providers. @vconzola do these screenshots look alright to you?

![s3-insecure-ssl-2](https://user-images.githubusercontent.com/628956/72011031-ff348700-3226-11ea-95b7-deb741cd4ee8.png)
![s3-insecure-ssl](https://user-images.githubusercontent.com/628956/72011030-ff348700-3226-11ea-8920-ae0b115a2c81.png)

