### PR TITLE
Added per-container split for logs

### DIFF
--- a/src/app/logs/components/LogFooter.tsx
+++ b/src/app/logs/components/LogFooter.tsx
@@ -6,11 +6,11 @@ import { Button, CardFooter } from '@patternfly/react-core';
 import { FunctionComponent } from 'react';
 import { connect } from 'react-redux';
 import { LogActions } from '../duck';
-import { PodUnselected } from './LogsContainer';
+import { LogUnselected, ILogSource } from './LogsContainer';
 import { IPlanLogSources } from '../../../client/resources/discovery';
 
 interface IProps {
-  podIndex: number;
+  logSource: ILogSource;
   cluster: string;
   isFetchingLogs: boolean;
   report: IPlanLogSources;
@@ -20,7 +20,7 @@ interface IProps {
 }
 
 const LogFooter: FunctionComponent<IProps> = ({
-  podIndex,
+  logSource,
   cluster,
   report,
   isFetchingLogs,
@@ -30,7 +30,12 @@ const LogFooter: FunctionComponent<IProps> = ({
 }) => {
 
   const requestDownload = (_) => {
-    requestDownloadLog(report[cluster][podIndex].log);
+    requestDownloadLog(
+      report[cluster]
+      [logSource.podIndex]
+        .containers
+      [logSource.containerIndex]
+        .log);
   };
 
   return (<CardFooter style={{ height: '5%' }}>
@@ -39,7 +44,7 @@ const LogFooter: FunctionComponent<IProps> = ({
         <Box flex="0" mx="1em">
           <Button
             onClick={requestDownload}
-            isDisabled={!report || podIndex === PodUnselected}
+            isDisabled={!report || logSource.podIndex === LogUnselected}
             variant="primary"
           >
             Download Selected

--- a/src/app/logs/components/LogHeader.tsx
+++ b/src/app/logs/components/LogHeader.tsx
@@ -44,12 +44,12 @@ const LogHeader: FunctionComponent<IProps> = ({
 
   const logSources = report && report[cluster.value]
     ? flatten(report[cluster.value].map(
-      (pod: IPodLogSource, index) =>
+      (pod: IPodLogSource, podIndex) =>
         pod.containers.map((container: IPodContainer, containerIndex) => ({
           label: `${pod.name}-${container.name}`,
           value: {
-            podIndex: index,
-            logIndex: containerIndex,
+            podIndex,
+            containerIndex,
           },
         }))))
     : [];
@@ -81,9 +81,15 @@ const LogHeader: FunctionComponent<IProps> = ({
             <Select
               name="selectPod"
               value={logSource}
-              onChange={(pod: ILogSource) => {
-                setLogSource(pod);
-                logFetchRequest(report[cluster.value][pod.podIndex].containers[pod.containerIndex].log);
+              onChange={(logSelection) => {
+                setLogSource(logSelection);
+                const logStore: ILogSource = logSelection.value;
+                logFetchRequest(
+                  report[cluster.value]
+                  [logStore.podIndex]
+                    .containers
+                  [logStore.containerIndex]
+                    .log);
               }}
               options={logSources}
             />

--- a/src/app/logs/components/LogsContainer.tsx
+++ b/src/app/logs/components/LogsContainer.tsx
@@ -104,7 +104,7 @@ const LogsContainer: FunctionComponent<IProps> = ({
       <LogBody />
       <LogFooter
         cluster={cluster.value}
-        logSource={logSource}
+        logSource={logSource.value}
         planName={planName} />
     </Card>
   );

--- a/src/app/logs/components/LogsContainer.tsx
+++ b/src/app/logs/components/LogsContainer.tsx
@@ -28,8 +28,12 @@ interface IProps {
   requestReport: (planName: string) => void;
   logErrorMsg: string;
 }
+export interface ILogSource {
+  podIndex: number;
+  containerIndex: number;
+}
 
-export const PodUnselected = -1;
+export const LogUnselected = -1;
 
 const LogsContainer: FunctionComponent<IProps> = ({
   requestReport,
@@ -41,9 +45,12 @@ const LogsContainer: FunctionComponent<IProps> = ({
     label: 'controller',
     value: 'controller'
   });
-  const [podIndex, setPodIndex] = useState({
+  const [logSource, setLogSource] = useState({
     label: null,
-    value: PodUnselected,
+    value: {
+      podIndex: LogUnselected,
+      containerIndex: LogUnselected,
+    },
   });
   const pollingContext = useContext(PollingContext);
   const [downloadLink, setDownloadLink] = useState(null);
@@ -90,14 +97,14 @@ const LogsContainer: FunctionComponent<IProps> = ({
     <Card>
       <LogHeader
         cluster={cluster}
-        podIndex={podIndex}
+        logSource={logSource}
         setCluster={setCluster}
-        setPodIndex={setPodIndex}
+        setLogSource={setLogSource}
       />
       <LogBody />
       <LogFooter
         cluster={cluster.value}
-        podIndex={podIndex.value}
+        logSource={logSource}
         planName={planName} />
     </Card>
   );

--- a/src/app/logs/duck/sagas.ts
+++ b/src/app/logs/duck/sagas.ts
@@ -40,14 +40,12 @@ function* downloadLogs(action) {
   try {
     const archive = new JSZip();
     const logPaths = flatten(Object.values(ClusterKind).map(
-      src => report[src].map(pod => pod.log)));
+      src => report[src].map(
+        pod => pod.containers.map(
+          container => container.log
+        ))));
 
-    const logs = [];
-    for (const log of logPaths) {
-      const text = yield discoveryClient.getRaw(log);
-      logs.push(text);
-    }
-
+    const logs = yield all(logPaths.map(log => discoveryClient.getRaw(log)));
 
     logs.map((log, index) => {
       const fullPath = logPaths[index].split(/\//);

--- a/src/client/resources/discovery.ts
+++ b/src/client/resources/discovery.ts
@@ -7,10 +7,15 @@ export enum ClusterKind {
   controller = 'controller',
 }
 
+export interface IPodContainer {
+  name: string;
+  log: string;
+}
+
 export interface IPodLogSource {
   name: string;
   namespace: string;
-  log: string;
+  containers: IPodContainer[];
 }
 
 export type IPlanLogSources = {


### PR DESCRIPTION
Leverage https://github.com/fusor/mig-controller/pull/398 by taking in account pod containers as the path for logs.