### PR TITLE
Bug 1790966 - [MIG-UI] Edit plan shows wrong information

### DIFF
--- a/src/app/plan/components/Wizard/WizardContainer.tsx
+++ b/src/app/plan/components/Wizard/WizardContainer.tsx
@@ -95,6 +95,7 @@ const WizardContainer = withFormik<IOtherProps, IFormValues>({
     return null;
   },
   validateOnBlur: false,
+  enableReinitialize: true,
 })(WizardComponent);
 
 const mapStateToProps = state => {

--- a/src/app/plan/duck/reducers.ts
+++ b/src/app/plan/duck/reducers.ts
@@ -300,7 +300,8 @@ export const stopPlanPolling = (state = INITIAL_STATE, action) => {
 export const resetCurrentPlan = (state = INITIAL_STATE, action) => {
   return {
     ...state,
-    currentPlan: null
+    currentPlan: null,
+    sourceClusterNamespaces: []
   };
 };
 


### PR DESCRIPTION
This fix consists of two parts.

First one is related to a wrong `withFormik` usage, and is explained in this issue: https://github.com/jaredpalmer/formik/issues/600

The second problem, wrongly displayed namespaces in the `Wizard` step on plan edit was caused by a stale `sourceClusterNamespaces` variable in Redux state.