### PR TITLE
Use helperText props in FormGroup for help and validation messages in cluster form

### DIFF
--- a/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -13,7 +13,6 @@ import {
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { withFormik, FormikProps } from 'formik';
 import KeyDisplayIcon from '../../../common/components/KeyDisplayIcon';
-import FormErrorDiv from '../../../common/components/FormErrorDiv';
 import HideWrapper from '../../../common/components/HideWrapper';
 import utils from '../../../common/duck/utils';
 import {
@@ -87,7 +86,13 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
 
   return (
     <Form onSubmit={handleSubmit} style={{ marginTop: '24px' }}>
-      <FormGroup label="Cluster Name" isRequired fieldId={nameKey}>
+      <FormGroup
+        label="Cluster Name"
+        isRequired
+        fieldId={nameKey}
+        helperTextInvalid={touched.name && errors.name}
+        isValid={!(touched.name && errors.name)}
+      >
         <TextInput
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(nameKey)}
@@ -97,16 +102,16 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           type="text"
           id="cluster-name-input"
           isDisabled={currentStatus.mode === AddEditMode.Edit}
+          isValid={!(touched.name && errors.name)}
         />
-        {errors.name && touched.name && (
-          <FormErrorDiv id="feedback-name">{errors.name}</FormErrorDiv>
-        )}
       </FormGroup>
       <FormGroup
         label="URL"
         isRequired
         fieldId={urlKey}
         helperText="URL of the cluster's API server"
+        helperTextInvalid={touched.url && errors.url}
+        isValid={!(touched.url && errors.url)}
       >
         <TextInput
           onChange={formikHandleChange}
@@ -116,14 +121,16 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           name={urlKey}
           type="text"
           id="url-input"
+          isValid={!(touched.url && errors.url)}
         />
-        {errors.url && touched.url && <FormErrorDiv id="feedback-url">{errors.url}</FormErrorDiv>}
       </FormGroup>
       <FormGroup
         label="Service account token"
         isRequired
         fieldId={tokenKey}
         helperText="Copy and paste the cluster's service account token."
+        helperTextInvalid={touched.token && errors.token}
+        isValid={!(touched.token && errors.token)}
       >
         <HideWrapper onClick={toggleHideToken}>
           <KeyDisplayIcon id="accessKeyIcon" isHidden={isTokenHidden} />
@@ -136,10 +143,8 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           name={tokenKey}
           id="token-input"
           type={isTokenHidden ? 'password' : 'text'}
+          isValid={!(touched.token && errors.token)}
         />
-        {errors.token && touched.token && (
-          <FormErrorDiv id="feedback-token">{errors.token}</FormErrorDiv>
-        )}
       </FormGroup>
       <FormGroup label="Is this an azure cluster?" fieldId={tokenKey}>
         <Checkbox
@@ -153,7 +158,13 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         />
       </FormGroup>
       {values.isAzure && (
-        <FormGroup label="Azure resource group" isRequired fieldId={azureResourceGroupKey}>
+        <FormGroup
+          label="Azure resource group"
+          isRequired
+          fieldId={azureResourceGroupKey}
+          helperTextInvalid={touched.azureResourceGroup && errors.azureResourceGroup}
+          isValid={!(touched.azureResourceGroup && errors.azureResourceGroup)}
+        >
           <TextInput
             value={values.azureResourceGroup}
             onChange={formikHandleChange}
@@ -162,10 +173,8 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
             name={azureResourceGroupKey}
             id="azure-token-input"
             type="text"
+            isValid={!(touched.azureResourceGroup && errors.azureResourceGroup)}
           />
-          {errors.azureResourceGroup && touched.azureResourceGroup && (
-            <FormErrorDiv id="feedback-token">{errors.azureResourceGroup}</FormErrorDiv>
-          )}
         </FormGroup>
       )}
       <FormGroup fieldId={requireSSLKey}>
@@ -310,7 +319,7 @@ const AddEditClusterForm: any = withFormik({
     }
 
     if (values.isAzure && !values.azureResourceGroup) {
-      errors.azureResourceGroupi = 'Required';
+      errors.azureResourceGroup = 'Required';
     }
 
     return errors;

--- a/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
+++ b/src/app/cluster/components/AddEditClusterModal/AddEditClusterForm.tsx
@@ -102,7 +102,12 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           <FormErrorDiv id="feedback-name">{errors.name}</FormErrorDiv>
         )}
       </FormGroup>
-      <FormGroup label="Url" isRequired fieldId={urlKey}>
+      <FormGroup
+        label="URL"
+        isRequired
+        fieldId={urlKey}
+        helperText="URL of the cluster's API server"
+      >
         <TextInput
           onChange={formikHandleChange}
           onInput={formikSetFieldTouched(urlKey)}
@@ -114,7 +119,12 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
         />
         {errors.url && touched.url && <FormErrorDiv id="feedback-url">{errors.url}</FormErrorDiv>}
       </FormGroup>
-      <FormGroup label="Service account token" isRequired fieldId={tokenKey}>
+      <FormGroup
+        label="Service account token"
+        isRequired
+        fieldId={tokenKey}
+        helperText="Copy and paste the cluster's service account token."
+      >
         <HideWrapper onClick={toggleHideToken}>
           <KeyDisplayIcon id="accessKeyIcon" isHidden={isTokenHidden} />
         </HideWrapper>
@@ -142,7 +152,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           onBlur={handleBlur}
         />
       </FormGroup>
-      {values.isAzure &&
+      {values.isAzure && (
         <FormGroup label="Azure resource group" isRequired fieldId={azureResourceGroupKey}>
           <TextInput
             value={values.azureResourceGroup}
@@ -157,7 +167,7 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
             <FormErrorDiv id="feedback-token">{errors.azureResourceGroup}</FormErrorDiv>
           )}
         </FormGroup>
-      }
+      )}
       <FormGroup fieldId={requireSSLKey}>
         <Checkbox
           onChange={formikHandleChange}
@@ -183,7 +193,10 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           <Button
             type="submit"
             isDisabled={isAddEditButtonDisabled(
-              currentStatus, errors, touched, valuesHaveUpdate(values, currentCluster)
+              currentStatus,
+              errors,
+              touched,
+              valuesHaveUpdate(values, currentCluster)
             )}
             style={{ marginRight: '10px' }}
           >
@@ -191,9 +204,8 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           </Button>
           <Tooltip
             position={TooltipPosition.top}
-            content={<div>
-              Add or edit your cluster details
-            </div>}>
+            content={<div>Add or edit your cluster details</div>}
+          >
             <span className="pf-c-icon">
               <OutlinedQuestionCircleIcon />
             </span>
@@ -201,7 +213,8 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           <Button
             style={{ marginLeft: '10px', marginRight: '10px' }}
             isDisabled={isCheckConnectionButtonDisabled(
-              currentStatus, valuesHaveUpdate(values, currentCluster),
+              currentStatus,
+              valuesHaveUpdate(values, currentCluster)
             )}
             onClick={() => checkConnection(values.name)}
           >
@@ -209,9 +222,8 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
           </Button>
           <Tooltip
             position={TooltipPosition.top}
-            content={<div>
-              Re-check your cluster's connection state
-            </div>}>
+            content={<div>Re-check your cluster's connection state</div>}
+          >
             <span className="pf-c-icon">
               <OutlinedQuestionCircleIcon />
             </span>
@@ -225,13 +237,10 @@ const InnerAddEditClusterForm = (props: IOtherProps & FormikProps<IFormValues>) 
             statusText={currentStatusFn(currentStatus)}
           />
         </GridItem>
-
       </Grid>
       <Grid gutter="md">
         <GridItem>
-          <Button
-            variant="primary"
-            onClick={onClose}>
+          <Button variant="primary" onClick={onClose}>
             Close
           </Button>
         </GridItem>

--- a/src/app/common/components/FormErrorDiv.tsx
+++ b/src/app/common/components/FormErrorDiv.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 const styles = require('./FormError.module')
 
+// TODO this should be removed in favor of using the `helperTextInvalid` and `isValid` props of `FormGroup`. 
 const FormErrorDiv = (props) => (
   <div className={styles.formErrorDiv}>{props.children}</div>
 );


### PR DESCRIPTION
Fixes #356.

Discussing with @vconzola, we decided that to align with [PatternFly design guidelines for forms](https://www.patternfly.org/v4/design-guidelines/usage-and-behavior/forms), the help text mocked up as popovers in the issue should instead be placed below the text fields using the `helperText` prop of `FormGroup`. Also, this form previously used a special `FormErrorDiv` below the fields to display validation errors, but we should instead use `helperTextInvalid` and mark the `FormGroup`s and `TextInput`s as `isValid={false}` when validation errors are present for that field. This takes up less vertical space, replaces the initial `helperText` if errors are present, and gives the field error styles (red border on the bottom, red alert icon at the right side).

This PR makes these changes in the `AddEditClusterForm` only, but we should use this anywhere we have form help text and validation messages and we should remove `FormErrorDiv` once we've done this everywhere. I opened a new issue for that: https://github.com/fusor/mig-ui/issues/692

This PR also fixes a bug where the `azureResourceGroup` field would not display its validation error due to a typo in the validate function.

# Before

## No validation errors
<img width="565" alt="Screenshot 2020-02-21 16 32 32" src="https://user-images.githubusercontent.com/811963/75073744-16be8b00-54c8-11ea-84e1-374a7526b6b4.png">

## With validation errors
<img width="563" alt="Screenshot 2020-02-21 16 32 52" src="https://user-images.githubusercontent.com/811963/75073747-1a521200-54c8-11ea-88f9-919a0a9baeac.png">


# After

## No validation errors
<img width="563" alt="Screenshot 2020-02-21 16 23 47" src="https://user-images.githubusercontent.com/811963/75073759-23db7a00-54c8-11ea-80b7-ae8501eee6b0.png">


## With validation errors
<img width="563" alt="Screenshot 2020-02-21 16 24 17" src="https://user-images.githubusercontent.com/811963/75073762-26d66a80-54c8-11ea-91fd-14b8416d588d.png">

