### PR TITLE
Clean up remaining form validation code, remove FormErrorDiv

### DIFF
--- a/src/app/common/components/FormError.module.scss
+++ b/src/app/common/components/FormError.module.scss
@@ -1,6 +1,0 @@
-@import 'src/colors' ;
- 
- .formErrorDiv {
-    margin: 1em 0 0 0;
-    color: $statusRed;
- }

--- a/src/app/common/components/FormErrorDiv.tsx
+++ b/src/app/common/components/FormErrorDiv.tsx
@@ -1,9 +1,0 @@
-import * as React from 'react';
-const styles = require('./FormError.module')
-
-// TODO this should be removed in favor of using the `helperTextInvalid` and `isValid` props of `FormGroup`. 
-const FormErrorDiv = (props) => (
-  <div className={styles.formErrorDiv}>{props.children}</div>
-);
-
-export default FormErrorDiv;

--- a/src/app/storage/components/AddEditStorageModal/ProviderForms/AWSForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/ProviderForms/AWSForm.tsx
@@ -6,12 +6,10 @@ import {
     FormGroup,
     Tooltip,
     TooltipPosition,
-    TextArea,
     Checkbox,
     Grid,
     GridItem
 } from '@patternfly/react-core';
-import FormErrorDiv from '../../../../common/components/FormErrorDiv';
 import KeyDisplayIcon from '../../../../common/components/KeyDisplayIcon';
 import HideWrapper from '../../../../common/components/HideWrapper';
 import {
@@ -135,7 +133,13 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
 
     return (
         <Form onSubmit={handleSubmit} style={{ marginTop: '24px' }}>
-            <FormGroup label="Replication repository name" isRequired fieldId={nameKey}>
+            <FormGroup
+                label="Replication repository name"
+                isRequired
+                fieldId={nameKey}
+                helperTextInvalid={touched.name && errors.name}
+                isValid={!(touched.name && errors.name)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(nameKey)}
@@ -145,12 +149,16 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     type="text"
                     id="storage-name-input"
                     isDisabled={currentStatus.mode === AddEditMode.Edit}
+                    isValid={!(touched.name && errors.name)}
                 />
-                {errors.name && touched.name && (
-                    <FormErrorDiv id="feedback-name">{errors.name}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="S3 bucket name" isRequired fieldId={awsBucketNameKey}>
+            <FormGroup
+                label="S3 bucket name"
+                isRequired
+                fieldId={awsBucketNameKey}
+                helperTextInvalid={touched.awsBucketName && errors.awsBucketName}
+                isValid={!(touched.awsBucketName && errors.awsBucketName)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(awsBucketNameKey)}
@@ -159,12 +167,15 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={awsBucketNameKey}
                     type="text"
                     id="storage-bucket-name-input"
+                    isValid={!(touched.awsBucketName && errors.awsBucketName)}
                 />
-                {errors.awsBucketName && touched.awsBucketName && (
-                    <FormErrorDiv id="feedback-bucket-name">{errors.awsBucketName}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="S3 bucket region" fieldId={awsBucketRegionKey}>
+            <FormGroup
+                label="S3 bucket region"
+                fieldId={awsBucketRegionKey}
+                helperTextInvalid={touched.awsBucketRegion && errors.awsBucketRegion}
+                isValid={!(touched.awsBucketRegion && errors.awsBucketRegion)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(awsBucketRegionKey)}
@@ -173,12 +184,15 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={awsBucketRegionKey}
                     type="text"
                     id="storage-bucket-region-input"
+                    isValid={!(touched.awsBucketRegion && errors.awsBucketRegion)}
                 />
-                {errors.awsBucketRegion && touched.awsBucketRegion && (
-                    <FormErrorDiv id="feedback-bucket-name">{errors.awsBucketName}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="S3 endpoint" fieldId={s3UrlKey}>
+            <FormGroup
+                label="S3 endpoint"
+                fieldId={s3UrlKey}
+                helperTextInvalid={touched.s3Url && errors.s3Url}
+                isValid={!(touched.s3Url && errors.s3Url)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(s3UrlKey)}
@@ -187,12 +201,16 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={s3UrlKey}
                     type="text"
                     id="storage-s3-url-input"
+                    isValid={!(touched.s3Url && errors.s3Url)}
                 />
-                {errors.s3Url && touched.s3Url && (
-                    <FormErrorDiv id="feedback-s3-url">{errors.s3Url}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="S3 provider access key" isRequired fieldId={accessKeyKey}>
+            <FormGroup
+                label="S3 provider access key"
+                isRequired
+                fieldId={accessKeyKey}
+                helperTextInvalid={touched.accessKey && errors.accessKey}
+                isValid={!(touched.accessKey && errors.accessKey)}
+            >
                 <HideWrapper onClick={handleAccessKeyHiddenToggle}>
                     <KeyDisplayIcon id="accessKeyIcon" isHidden={isAccessKeyHidden} />
                 </HideWrapper>
@@ -204,12 +222,16 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={accessKeyKey}
                     type={isAccessKeyHidden ? 'password' : 'text'}
                     id="storage-access-key-input"
+                    isValid={!(touched.accessKey && errors.accessKey)}
                 />
-                {errors.accessKey && touched.accessKey && (
-                    <FormErrorDiv id="feedback-access-key">{errors.accessKey}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="S3 provider secret access key" isRequired fieldId={secretKey}>
+            <FormGroup
+                label="S3 provider secret access key"
+                isRequired
+                fieldId={secretKey}
+                helperTextInvalid={touched.secret && errors.secret}
+                isValid={!(touched.secret && errors.secret)}
+            >
                 <HideWrapper onClick={handleSecretHiddenToggle}>
                     <KeyDisplayIcon id="accessKeyIcon" isHidden={isSecretHidden} />
                 </HideWrapper>
@@ -221,10 +243,8 @@ const InnerAWSForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={secretKey}
                     type={isSecretHidden ? 'password' : 'text'}
                     id="storage-secret-input"
+                    isValid={!(touched.secret && errors.secret)}
                 />
-                {errors.secret && touched.secret && (
-                    <FormErrorDiv id="feedback-secret-key">{errors.secret}</FormErrorDiv>
-                )}
             </FormGroup>
             <FormGroup fieldId={requireSSLKey}>
                 <Checkbox

--- a/src/app/storage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
@@ -337,7 +337,7 @@ const AzureForm: any = withFormik({
         }
 
         if (!values.azureBlob) {
-            errors.azureBlop = 'Required';
+            errors.azureBlob = 'Required';
         }
 
         return errors;

--- a/src/app/storage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/ProviderForms/AzureForm.tsx
@@ -11,7 +11,6 @@ import {
     Grid,
     GridItem
 } from '@patternfly/react-core';
-import FormErrorDiv from '../../../../common/components/FormErrorDiv';
 import {
     AddEditMode,
     addEditStatusText,
@@ -102,7 +101,13 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
 
     return (
         <Form onSubmit={handleSubmit} style={{ marginTop: '24px' }}>
-            <FormGroup label="Repository name" isRequired fieldId={nameKey}>
+            <FormGroup
+                label="Repository name"
+                isRequired
+                fieldId={nameKey}
+                helperTextInvalid={touched.name && errors.name}
+                isValid={!(touched.name && errors.name)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(nameKey)}
@@ -112,12 +117,16 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     type="text"
                     id="storage-name-input"
                     isDisabled={currentStatus.mode === AddEditMode.Edit}
+                    isValid={!(touched.name && errors.name)}
                 />
-                {errors.name && touched.name && (
-                    <FormErrorDiv id="feedback-name">{errors.name}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="Azure resource group" isRequired fieldId={azureResourceGroupKey}>
+            <FormGroup
+                label="Azure resource group"
+                isRequired
+                fieldId={azureResourceGroupKey}
+                helperTextInvalid={touched.azureResourceGroup && errors.azureResourceGroup}
+                isValid={!(touched.azureResourceGroup && errors.azureResourceGroup)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(azureResourceGroupKey)}
@@ -126,12 +135,16 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={azureResourceGroupKey}
                     type="text"
                     id="azure-resource-group-input"
+                    isValid={!(touched.azureResourceGroup && errors.azureResourceGroup)}
                 />
-                {errors.azureResourceGroup && touched.azureResourceGroup && (
-                    <FormErrorDiv id="azure-resource-group-input-error">{errors.azureResourceGroup}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="Azure storage account name" isRequired fieldId={azureStorageAccountKey}>
+            <FormGroup
+                label="Azure storage account name"
+                isRequired
+                fieldId={azureStorageAccountKey}
+                helperTextInvalid={touched.azureStorageAccount && errors.azureStorageAccount}
+                isValid={!(touched.azureStorageAccount && errors.azureStorageAccount)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(azureStorageAccountKey)}
@@ -140,15 +153,15 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={azureStorageAccountKey}
                     type="text"
                     id="azure-storage-input"
+                    isValid={!(touched.azureStorageAccount && errors.azureStorageAccount)}
                 />
-                {errors.azureStorageAccount && touched.azureStorageAccount && (
-                    <FormErrorDiv id="azure-storage-input-error">{errors.azureStorageAccount}</FormErrorDiv>
-                )}
             </FormGroup>
             <FormGroup
                 label="Azure credentials (Copy and paste .INI file contents here)"
                 isRequired
                 fieldId={azureBlobKey}
+                helperTextInvalid={touched.azureBlob && errors.azureBlob}
+                isValid={!(touched.azureBlob && errors.azureBlob)}
             >
                 <TextArea
                     onChange={formikHandleChange}
@@ -158,10 +171,8 @@ const InnerAzureForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={azureBlobKey}
                     type="text"
                     id="storage-blob-input"
+                    isValid={!(touched.azureBlob && errors.azureBlob)}
                 />
-                {errors.azureBlob && touched.azureBlob && (
-                    <FormErrorDiv id="feedback-access-key">{errors.azureBlob}</FormErrorDiv>
-                )}
             </FormGroup>
             <Grid gutter="md">
                 <GridItem>

--- a/src/app/storage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
@@ -9,7 +9,6 @@ import {
     Grid,
     GridItem
 } from '@patternfly/react-core';
-import FormErrorDiv from '../../../../common/components/FormErrorDiv';
 import KeyDisplayIcon from '../../../../common/components/KeyDisplayIcon';
 import HideWrapper from '../../../../common/components/HideWrapper';
 import {
@@ -97,7 +96,13 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
 
     return (
         <Form onSubmit={handleSubmit} style={{ marginTop: '24px' }}>
-            <FormGroup label="Repository name" isRequired fieldId={nameKey}>
+            <FormGroup
+                label="Repository name"
+                isRequired
+                fieldId={nameKey}
+                helperTextInvalid={touched.name && errors.name}
+                isValid={!(touched.name && errors.name)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(nameKey)}
@@ -107,12 +112,16 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     type="text"
                     id="storage-name-input"
                     isDisabled={currentStatus.mode === AddEditMode.Edit}
+                    isValid={!(touched.name && errors.name)}
                 />
-                {errors.name && touched.name && (
-                    <FormErrorDiv id="feedback-name">{errors.name}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="GCP bucket name" isRequired fieldId={gcpBucketKey}>
+            <FormGroup
+                label="GCP bucket name"
+                isRequired
+                fieldId={gcpBucketKey}
+                helperTextInvalid={touched.gcpBucket && errors.gcpBucket}
+                isValid={!(touched.gcpBucket && errors.gcpBucket)}
+            >
                 <TextInput
                     onChange={formikHandleChange}
                     onInput={formikSetFieldTouched(gcpBucketKey)}
@@ -121,12 +130,16 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={gcpBucketKey}
                     type="text"
                     id="storage-bucket-name-input"
+                    isValid={!(touched.gcpBucket && errors.gcpBucket)}
                 />
-                {errors.gcpBucket && touched.gcpBucket && (
-                    <FormErrorDiv id="feedback-bucket-name">{errors.gcpBucket}</FormErrorDiv>
-                )}
             </FormGroup>
-            <FormGroup label="GCP credential JSON blob" isRequired fieldId={gcpBlobKey}>
+            <FormGroup
+                label="GCP credential JSON blob"
+                isRequired
+                fieldId={gcpBlobKey}
+                helperTextInvalid={touched.gcpBlob && errors.gcpBlob}
+                isValid={!(touched.gcpBlob && errors.gcpBlob)}
+            >
                 <HideWrapper onClick={handleBlobHiddenToggle}>
                     <KeyDisplayIcon id="gcpBlobIcon" isHidden={isBlobHidden} />
                 </HideWrapper>
@@ -138,10 +151,8 @@ const InnerGCPForm = (props: IOtherProps & FormikProps<IFormValues>) => {
                     name={gcpBlobKey}
                     type={isBlobHidden ? 'password' : 'text'}
                     id="storage-blob-input"
+                    isValid={!(touched.gcpBlob && errors.gcpBlob)}
                 />
-                {errors.gcpBlob && touched.gcpBlob && (
-                    <FormErrorDiv id="feedback-access-key">{errors.gcpBlob}</FormErrorDiv>
-                )}
             </FormGroup>
             <Grid gutter="md">
                 <GridItem>

--- a/src/app/storage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
+++ b/src/app/storage/components/AddEditStorageModal/ProviderForms/GCPForm.tsx
@@ -236,11 +236,11 @@ const GCPForm: any = withFormik({
 
         if (!values.gcpBucket) {
             errors.gcpBucket = 'Required';
-        }
-
-        const gcpBucketNameError = storageUtils.testS3Name(values.gcpBucket);
-        if (gcpBucketNameError !== '') {
-            errors.gcpBucket = gcpBucketNameError;
+        } else {
+            const gcpBucketNameError = storageUtils.testS3Name(values.gcpBucket);
+            if (gcpBucketNameError !== '') {
+                errors.gcpBucket = gcpBucketNameError;
+            }
         }
 
         if (!values.gcpBlob) {


### PR DESCRIPTION
Fixes #692 

This PR takes the changes made to the AddEditClusterForm in https://github.com/fusor/mig-ui/pull/691 and repeats them on the rest of the forms that were using FormErrorDiv for validation errors (the 3 forms in the Add replication repository modal).

I also found and fixed two validation bugs in these forms:
* In the GCPForm, the "Required" error would never appear since the other error condition ("The bucket name can be between 3 and 63 characters long") is true in the case of an empty value. I moved the character length condition into an else case so "Required" will appear instead if the field is left blank.
* In the AzureForm, the "Azure credentials" textarea field could not show validation errors because of a typo in the validate function.

# AWSForm

## Before
<img width="518" alt="Screenshot 2020-02-24 19 31 37" src="https://user-images.githubusercontent.com/811963/75204237-57bfd500-573e-11ea-956a-4c849edb2536.png">

## After
<img width="511" alt="Screenshot 2020-02-24 19 35 10" src="https://user-images.githubusercontent.com/811963/75204263-65755a80-573e-11ea-9faf-24bd694d7c82.png">

# GCPForm

## Before
<img width="512" alt="Screenshot 2020-02-24 19 49 21" src="https://user-images.githubusercontent.com/811963/75204411-cef56900-573e-11ea-85cf-45911da3dcd2.png">


## After
<img width="513" alt="Screenshot 2020-02-24 19 48 54" src="https://user-images.githubusercontent.com/811963/75204417-d3218680-573e-11ea-8e36-edd37809b901.png">

![tJNUdCZ47z](https://user-images.githubusercontent.com/811963/75204510-14b23180-573f-11ea-9b9a-b9d3c61e3f94.gif)


# AzureForm

## Before
<img width="510" alt="Screenshot 2020-02-24 19 32 28" src="https://user-images.githubusercontent.com/811963/75204330-8f2e8180-573e-11ea-8d2c-bf6c30bb879a.png">

## After
<img width="508" alt="Screenshot 2020-02-24 19 36 57" src="https://user-images.githubusercontent.com/811963/75204336-948bcc00-573e-11ea-81ff-bdf59c378aa4.png">
