### PR TITLE
Bug 2082221: Don't allow SCC migration when only one storage class is present or when no PVs are selected

### DIFF
--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesForm.tsx
@@ -142,9 +142,7 @@ const VolumesForm: React.FunctionComponent<IOtherProps> = (props) => {
     <VolumesTable
       isEdit={props.isEdit}
       isOpen={props.isOpen}
-      storageClasses={
-        (planState.currentPlan && planState.currentPlan.status.destStorageClasses) || []
-      }
+      storageClasses={planState.currentPlan?.status.destStorageClasses || []}
     />
   );
 };

--- a/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/VolumesTable.tsx
@@ -18,6 +18,9 @@ import {
   EmptyStateVariant,
   PopoverPosition,
   Title,
+  Alert,
+  AlertActionLink,
+  WizardContext,
 } from '@patternfly/react-core';
 import {
   sortable,
@@ -412,6 +415,8 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
     };
   });
 
+  const { goToStepByName, onClose } = React.useContext(WizardContext);
+
   return (
     <Grid hasGutter>
       <GridItem>
@@ -423,6 +428,41 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
           </Text>
         </TextContent>
       </GridItem>
+      {isSCC && values.persistentVolumes.length === 0 ? (
+        <GridItem>
+          <Alert
+            variant="danger"
+            isInline
+            title="Storage class conversion is unavailable"
+            actionLinks={
+              <React.Fragment>
+                <AlertActionLink onClick={() => goToStepByName('General')}>Go back</AlertActionLink>
+                <AlertActionLink onClick={() => onClose()}>Cancel</AlertActionLink>
+              </React.Fragment>
+            }
+          >
+            At least one PV must be attached to the project for storage class conversion.
+          </Alert>
+        </GridItem>
+      ) : null}
+      {isSCC && storageClasses.length < 2 ? (
+        <GridItem>
+          <Alert
+            variant="danger"
+            isInline
+            title="Storage class conversion is unavailable"
+            actionLinks={
+              <React.Fragment>
+                <AlertActionLink onClick={() => goToStepByName('General')}>Go back</AlertActionLink>
+                <AlertActionLink onClick={() => onClose()}>Cancel</AlertActionLink>
+              </React.Fragment>
+            }
+          >
+            At least two storage classes must be available in the cluster for storage class
+            conversion.
+          </Alert>
+        </GridItem>
+      ) : null}
       <GridItem>
         <Level>
           <LevelItem>
@@ -503,7 +543,9 @@ const VolumesTable: React.FunctionComponent<IVolumesTableProps> = ({
             titleText={values.persistentVolumes.length === 0 && 'No persistent volumes found'}
             bodyText={
               values.persistentVolumes.length === 0 &&
-              'No persistent volumes are attached to the selected projects. Click Next to continue.'
+              `No persistent volumes are attached to the selected projects.${
+                !isSCC ? ' Click Next to continue.' : ''
+              }`
             }
           />
         )}

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardComponent.tsx
@@ -292,6 +292,9 @@ const WizardComponent = (props: IOtherProps) => {
     });
   };
 
+  const planState = useSelector((state: DefaultRootState) => state.plan);
+  const storageClasses = planState.currentPlan?.status.destStorageClasses || [];
+
   const CustomFooter = (
     <WizardFooter>
       <WizardContextConsumer>
@@ -302,7 +305,7 @@ const WizardComponent = (props: IOtherProps) => {
                 {
                   if (
                     values.migrationType.value === 'full' ||
-                    values.migrationType.value == 'state'
+                    values.migrationType.value === 'state'
                   ) {
                     return areFieldsTouchedAndValid([
                       'planName',
@@ -324,7 +327,9 @@ const WizardComponent = (props: IOtherProps) => {
                   !isFetchingPVResources &&
                   !isFetchingPVList &&
                   currentPlanStatus.state !== 'Pending' &&
-                  currentPlanStatus.state !== 'Critical'
+                  currentPlanStatus.state !== 'Critical' &&
+                  (values.migrationType.value !== 'scc' ||
+                    (values.selectedPVs.length > 0 && storageClasses.length > 1))
                 );
               case 'Hooks':
                 return !isAddHooksOpen;

--- a/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
+++ b/src/app/home/pages/PlansPage/components/Wizard/WizardFormik.tsx
@@ -52,10 +52,7 @@ const WizardFormik: React.FunctionComponent<IWizardFormikProps> = ({
         if (!values.selectedNamespaces || values.selectedNamespaces.length === 0) {
           errors.selectedNamespaces = 'Required';
         }
-        if (
-          values.migrationType.value !== 'scc' &&
-          (!values.selectedPVs || values.selectedPVs.length === 0)
-        ) {
+        if (!values.selectedPVs || values.selectedPVs.length === 0) {
           errors.selectedPVs = 'Required';
         }
 


### PR DESCRIPTION
Resolves https://bugzilla.redhat.com/show_bug.cgi?id=2082221 by changing the logic to match the backend conditions that were added in https://github.com/konveyor/mig-controller/pull/1275/files#diff-c8f35369a2e13b75bfb6f5aeded0089876b651cf4498b332854c0504a5a6a954R1281-R1298 .

**Note:** this PR reverts some of the logic in https://github.com/konveyor/mig-ui/pull/1404. We should re-verify the related BZ https://bugzilla.redhat.com/show_bug.cgi?id=2071000 when verifying this one to ensure we don't have a regression.

<img width="1704" alt="Screen Shot 2022-05-09 at 11 57 30 AM" src="https://user-images.githubusercontent.com/811963/167450311-a01a12c7-62c3-4d20-b07f-3dc1a28d5541.png">

<img width="1712" alt="Screen Shot 2022-05-09 at 12 05 01 PM" src="https://user-images.githubusercontent.com/811963/167450995-5c056fe4-fc61-4d76-8201-885a8199dbec.png">

